### PR TITLE
Remove explicit Ruby version declaration in the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,6 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.6.2'
-
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.3'
 # Use postgresql as the database for Active Record


### PR DESCRIPTION
Its presence seems to cause issues with invoking bundler, including the
following error:
```
Your Ruby version is 2.6.3, but your Gemfile specified 2.6.2
```
Removing this strictness resolves that error, without any side effects.