### PR TITLE
hotfix for images in markdown description

### DIFF
--- a/app/assets/stylesheets/components/markdown.scss
+++ b/app/assets/stylesheets/components/markdown.scss
@@ -1,10 +1,11 @@
 section.markdown {
   img {
-    width: auto !important;
-    height: auto !important;
+    width: 100% !important;
+    height: 100% !important;
   }
 
-  ul, li {
+  ul,
+  li {
     list-style: circle;
     padding-left: 0.5em;
   }


### PR DESCRIPTION
![Screen Shot 2020-08-16 at 1 48 02 pm](https://user-images.githubusercontent.com/13824586/90326062-1ca0af00-dfc7-11ea-942d-8d1b798ec7dd.png)
Added a hot-fix for markdown images - it shouldnt be going off the screen :) 