### PR TITLE
Issue templates etc

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,6 +11,9 @@ assignees: ''
 
 <!--
 A clear and concise description of what the bug is.
+
+Note:
+Text between <!-- and --​> marks will be invisible in the report.
 -->
 
 **To Reproduce**

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,59 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: 'bug'
+assignees: ''
+
+---
+
+**Describe the bug**
+
+<!--
+A clear and concise description of what the bug is.
+-->
+
+**To Reproduce**
+
+<!--
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+-->
+
+**Expected behavior**
+
+<!--
+A clear and concise description of what you expected to happen.
+-->
+
+**Screenshots**
+
+<!--
+If applicable, add screenshots to help explain your problem.
+-->
+
+**Desktop (please complete the following information):**
+
+<!--
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+-->
+
+**Smartphone (please complete the following information):**
+
+<!--
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+-->
+
+**Additional context**
+
+<!--
+Add any other context about the problem here.
+-->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,32 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: 'enhancement'
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+
+<!--
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+-->
+
+**Describe the solution you'd like**
+
+<!--
+A clear and concise description of what you want to happen.
+-->
+
+**Describe alternatives you've considered**
+
+<!--
+A clear and concise description of any alternative solutions or features you've considered.
+-->
+
+**Additional context**
+
+<!--
+Add any other context or screenshots about the feature request here.
+-->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -11,6 +11,9 @@ assignees: ''
 
 <!--
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+Note:
+Text between <!-- and --​> marks will be invisible in the report.
 -->
 
 **Describe the solution you'd like**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,6 @@
+### Pull Request Checklist
+
+<!-- Please read CONTRIBUTING.md before submitting your pull request -->
+
+* [ ] Pull request is based on the `main` branch
+* [ ] Pull request includes a [sign off](../CONTRIBUTING.md#sign-off)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,30 @@
+# GovHack Code of Conduct
+
+All participants, competitors, hosts, volunteers, sponsors, mentors, data custodians, and observers at GovHack and GovHack events must agree with the following code of conduct. We expect cooperation from all participants to help ensure a safe environment for everybody.
+
+Tl;dr Be awesome. Be polite and friendly to everyone involved in GovHack.
+
+# Need Help?
+
+If you have witnessed or experienced any transgressions of this Code of Conduct at a GovHack event please speak to the organiser of your event and send an email to conduct@govhack.org for our records. The organiser’s details may be on the back of your name badge, otherwise ask a volunteer who to talk to.
+
+# Short version
+
+GovHack is dedicated to providing a harassment-free experience for everyone regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age, religion or technology choices. We do not tolerate harassment in any form. Sexual language and imagery are not appropriate at any GovHack event including but not limited to hack events, connections event, awards event, talks, workshops, parties, social media and other online media. Event participants violating these rules may be sanctioned or expelled from GovHack events at the discretion of GovHack organisers.
+
+# Long version
+
+Harassment includes offensive verbal comments related to gender, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, nationality, religion, sexual images in public spaces, deliberate intimidation, stalking, following, photography or audio/video recording against reasonable consent, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention.
+
+Photography is encouraged, but other participants must be given a reasonable chance to opt out from being photographed. If they object to the taking of their photograph, photographers must comply with their request.
+
+As this is a hackathon, we like to explicitly note that the hacks created at our hackathon are equally subject to the anti-harassment policy.
+
+Participants asked to stop any harassing behaviour are expected to comply immediately.
+
+If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a GovHack organiser immediately.
+
+If a participant engages in harassing behavior, the GovHack organisers may take any action they deem appropriate, including warning the offender or expelling them from the event.
+
+We expect participants to follow these rules at all GovHack events, workshop venues and hackathon-related social events.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,68 @@
+# How to contribute
+
+To contribute, we encourage you to create useful Issues for us to work on, either bug reports or feature requests.
+
+If you're feeling more adventurous, take a look about our [good first
+issue](../../issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+list, for some issues that may be easy for new contributors to help with.
+
+Please [sign off](#sign-off) your contributions.
+
+## Sign off
+
+A Sign-Off helps us to keep a written record that authors of contributions
+agree to release them under our project's [license](LICENSE). We've adopted the
+DCO (Developer Certificate of Origin: http://developercertificate.org/) for
+this purpose:
+
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+660 York Street, Suite 102,
+San Francisco, CA 94110 USA
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+
+If you agree to make your contribution under the above terms, all you need to
+do is include a line like the following in your commit message or pull request
+comment:
+
+```
+Signed-off-by: Your Name <your@email.example.org>
+```
+
+Please use your legally identifiable name for your sign-off.
+
+Git allows you to add this signoff automatically when using the `-s`
+flag to `git commit`, which uses the name and email set in your
+`user.name` and `user.email` git configs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 # How to contribute
 
-To contribute, we encourage you to create useful Issues for us to work on, either bug reports or feature requests.
+To contribute, we encourage you to create useful Issues for us to work on,
+either bug reports or feature requests.
 
 If you're feeling more adventurous, take a look about our [good first
 issue](../../issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)


### PR DESCRIPTION
These are some good first drafts for making it easier to create useful PRs and Issues, as well as adding the GovHack Code of Conduct (which isn't as suited for code repo contributions as I might like, but is a start until we can rework it), and a request for users to sign-off commits to confirm they are their true author, and that they agree to release them under our license. I don't love requiring the "legal name" bit in the sign-off, since it may be triggering, uncomfortable, or outing, for people who don't use their legal name day-to-day (e.g. trans folks who haven't changed their legal name), but I suspect that strictly it may be necessary in this instance.

Feel free to provide feedback and/or only pull some of the suggested changes.