### PR TITLE
WIP Fix issues with Windows Docker setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,17 @@ $ rails server
 
 ## Docker Deployment Instructions
 
+If running on Windows, start by running the following in the cloned `hackerspace3` repo:
+
+(This is required because otherwise `docker-entrypoint.sh` has Windows line-endings, CRLF, instead of Linux line endings, LF, and can't be run by bash within the Docker system.)
+
+```bash
+git config --local core.autocrlf false
+git config --local core.eol lf
+rm -rf *
+git checkout .
+```
+
 Initialise environment variables required by `docker-compose`:
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,11 @@ services:
     env_file: .env
     ports:
       - 3000:3000
+    volumes:
+      - .:/usr/src/app
     restart: always
+    depends_on:
+      - postgres
 
   postgres:
     image: postgres:12.1


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the `main` branch
* [ ] Pull request includes a [sign off](../CONTRIBUTING.md#sign-off)

@waiholiu was saying there are still some issues with the Windows Docker setup. I'm doing some debugging to try to work out why. This is a first pass to improve things:

* I'm using the `docker-compose.yml` file to mount the checked out git repo into the container so devs can work on it without the nasty `docker-compose up -v` junk
* The container gets quite unhappy at CRLF line endings in files. @waiholiu put a fix in the README.md for `docker-entrypoint.sh`, but that's not the only issue. When I did a clone and built the image, *all* text files had CRLF line endings and Ruby complained lots and refused to load a page. Changing git config to force LF on checkout fixes this. No idea how it'll interact with devs' editors and IDEs though, and whether they'll try to override settings back to CRLF. Needs more investigation.