### PR TITLE
Implement Invisible Captcha

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,8 @@ gem 'font_awesome5_rails'
 gem 'graphql'
 # Mount the GraphiQL IDE in Ruby on Rails.
 gem 'graphiql-rails'
+# Complete and flexible spam protection solution for Rails applications.
+gem 'invisible_captcha'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,6 +176,8 @@ GEM
     hashie (4.1.0)
     i18n (1.8.9)
       concurrent-ruby (~> 1.0)
+    invisible_captcha (2.0.0)
+      rails (>= 5.0)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
     jmespath (1.4.0)
@@ -407,6 +409,7 @@ DEPENDENCIES
   guard-bundler
   guard-minitest
   guard-rubocop
+  invisible_captcha
   jbuilder (~> 2.5)
   jquery-rails
   letter_opener

--- a/app/controllers/agreements_controller.rb
+++ b/app/controllers/agreements_controller.rb
@@ -1,5 +1,6 @@
 class AgreementsController < ApplicationController
   before_action :authenticate_user!, :user
+  invisible_captcha only: :update, honeypot: :terms_and_conditions
 
   def edit; end
 

--- a/app/views/agreements/edit.html.erb
+++ b/app/views/agreements/edit.html.erb
@@ -8,6 +8,7 @@
         <div class="custom-control custom-checkbox">
           <%= f.check_box :accepted_terms_and_conditions, class: 'custom-control-input' %>
           <%= f.label :accepted_terms_and_conditions, 'I accept GovHack Terms and Conditions', class: 'custom-control-label' %>
+          <%= f.invisible_captcha :terms_and_conditions %>
         </div>
         <div class="actions">
           <%= f.submit 'Continue' %>

--- a/config/initializers/invisible_captcha.rb
+++ b/config/initializers/invisible_captcha.rb
@@ -2,7 +2,7 @@ InvisibleCaptcha.setup do |config|
   config.timestamp_enabled = !Rails.env.test?
   # config.honeypots           << ['more', 'fake', 'attribute', 'names']
   # config.visual_honeypots    = false
-  config.timestamp_threshold = 10
+  # config.timestamp_threshold = 2
   # config.timestamp_enabled   = true
   # config.injectable_styles   = false
   # config.spinner_enabled     = true

--- a/config/initializers/invisible_captcha.rb
+++ b/config/initializers/invisible_captcha.rb
@@ -1,0 +1,13 @@
+InvisibleCaptcha.setup do |config|
+  config.timestamp_enabled = !Rails.env.test?
+  # config.honeypots           << ['more', 'fake', 'attribute', 'names']
+  # config.visual_honeypots    = false
+  config.timestamp_threshold = 10
+  # config.timestamp_enabled   = true
+  # config.injectable_styles   = false
+  # config.spinner_enabled     = true
+
+  # Leave these unset if you want to use I18n (see below)
+  # config.sentence_for_humans     = 'If you are a human, ignore this field'
+  # config.timestamp_error_message = 'Sorry, that was too quick! Please resubmit.'
+end

--- a/test/controllers/agreements_controller_test.rb
+++ b/test/controllers/agreements_controller_test.rb
@@ -14,7 +14,7 @@ class AgreementsControllerTest < ActionDispatch::IntegrationTest
 
   test 'should patch update success' do
     patch agreement_path(@user), params: { user: {
-      accepted_terms_and_conditions: true
+      accepted_terms_and_conditions: true, terms_and_conditions: ''
     }}
     assert_redirected_to complete_registration_path
     @user.reload
@@ -23,10 +23,20 @@ class AgreementsControllerTest < ActionDispatch::IntegrationTest
 
   test 'should patch update fail' do
     patch agreement_path(@user), params: { user: {
-      accepted_terms_and_conditions: false
+      accepted_terms_and_conditions: false, terms_and_conditions: ''
     }}
     assert_redirected_to review_terms_and_conditions_path
     @user.reload
     assert @user.accepted_terms_and_conditions.nil?
   end
+
+  # Tried to write the below test but was not working ☹️
+  # test 'should patch update repel robot! 🤖' do
+  #   patch agreement_path(@user), params: { user: {
+  #     accepted_terms_and_conditions: true, terms_and_conditions: 'obey!'
+  #   }}
+  #   assert_response :success
+  #   @user.reload
+  #   assert @user.accepted_terms_and_conditions.nil?
+  # end
 end


### PR DESCRIPTION
## Background

We've been having problems with Robot's invading the Hackerspace.

Have decided to implement the unobtrusive [Invisible Captcha](https://github.com/markets/invisible_captcha) gem.

## Tasks 

- [ ] Check out config/initializers/invisible_captcha.rb and see if there is any other configuration options we would like to set.