### PR TITLE
Move Invisible Captcha to Registration Form

### DIFF
--- a/app/assets/stylesheets/components/flash_notification.scss
+++ b/app/assets/stylesheets/components/flash_notification.scss
@@ -17,6 +17,10 @@ p {
     background-color: #C00;
   }
 
+  &.error {
+    background-color: gray;
+  }
+
   &.notice {
     background-color: #4c9ad2;
   }

--- a/app/controllers/agreements_controller.rb
+++ b/app/controllers/agreements_controller.rb
@@ -1,6 +1,5 @@
 class AgreementsController < ApplicationController
   before_action :authenticate_user!, :user
-  invisible_captcha only: :update, honeypot: :terms_and_conditions
 
   def edit; end
 

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,10 @@
+class Users::RegistrationsController < Devise::RegistrationsController
+  before_action :configure_sign_up_params, only: :create
+  invisible_captcha honeypot: :terms_and_conditions, only: :create
+
+  protected
+
+  def configure_sign_up_params
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:terms_and_conditions])
+  end
+end

--- a/app/views/agreements/edit.html.erb
+++ b/app/views/agreements/edit.html.erb
@@ -8,7 +8,6 @@
         <div class="custom-control custom-checkbox">
           <%= f.check_box :accepted_terms_and_conditions, class: 'custom-control-input' %>
           <%= f.label :accepted_terms_and_conditions, 'I accept GovHack Terms and Conditions', class: 'custom-control-label' %>
-          <%= f.invisible_captcha :terms_and_conditions %>
         </div>
         <div class="actions">
           <%= f.submit 'Continue' %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -22,6 +22,7 @@
           <%= f.label :password_confirmation %>
           <%= f.password_field :password_confirmation, autocomplete: "off", class: 'form-control' %>
         </div>
+        <%= f.invisible_captcha :terms_and_conditions %>
         <div class="actions">
           <%= f.submit "Sign Up" %>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,10 @@ Rails.application.routes.draw do
   post "/graphql", to: "graphql#execute"
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 
-  devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
+  devise_for :users, controllers: {
+    omniauth_callbacks: 'users/omniauth_callbacks',
+    registrations: 'users/registrations'
+  }
 
   resources :resources, only: :index do
     collection do


### PR DESCRIPTION
![Screen Shot 2021-05-14 at 9 41 07 am](https://user-images.githubusercontent.com/4644609/118200504-8f788100-b498-11eb-82b5-36d029963b33.png)

Prevents bots from signing up and using our email resources.

Requests to sign up will be rejected if 
- They are completed in under 2 seconds.
- They fill in the (invisible) `terms_and_conditions` field on page.