### PR TITLE
Add turbolinks:before-cache to prevent duplicate table initialisations

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -35,6 +35,12 @@ $( document ).on('turbolinks:load', function() {
 		responsive: true
 	});
 
+	// To avoid duplicate table initializations, make sure turbolinks only caches
+	// the orginial un-enhanced table.
+	$( document ).on('turbolinks:before-cache', function() {
+		table.destroy();
+	});
+
 	// Check if filter needs to be applied
 	if ((window._search != undefined) && (window._search.length > 0 )) {
 		// Apply the filter param to the filter box.


### PR DESCRIPTION
Prevents the below from happening...

<img width="1584" alt="Screen Shot 2021-07-11 at 9 08 06 am" src="https://user-images.githubusercontent.com/4644609/125178359-82bda280-e227-11eb-8ada-521086ba0342.png">
