### PR TITLE
Datatable control duplication fix

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -30,15 +30,16 @@ $(document).ready(function() {
 
 $( document ).on('turbolinks:load', function() {
 
-	// Check if table is already cached
-	if ($('[id$="table_wrapper"]').length < 1) {
+	// Initilize the table and save any state changes.
+	var table = $('[id$="table"]').DataTable({
+		stateSave: true,
+		responsive: true,
+		bAutoWidth: false
+	});
 
-		// Initilize the table and save any state changes.
-		var table = $('[id$="table"]').DataTable({
-			stateSave: true,
-			responsive: true
-		});
-	}
+	$(document).on('turbolinks:before-cache', function() {
+		table.destroy();
+	});
 
 	// Check if filter needs to be applied
 	if ((window._search != undefined) && (window._search.length > 0 )) {

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -29,11 +29,16 @@ $(document).ready(function() {
 });
 
 $( document ).on('turbolinks:load', function() {
-	// Initilize the table and save any state changes.
-	var table = $('[id$="table"]').DataTable({
-		stateSave: true,
-		responsive: true
-	});
+
+	// Check if table is already cached
+	if ($('[id$="table_wrapper"]').length < 1) {
+
+		// Initilize the table and save any state changes.
+		var table = $('[id$="table"]').DataTable({
+			stateSave: true,
+			responsive: true
+		});
+	}
 
 	// Check if filter needs to be applied
 	if ((window._search != undefined) && (window._search.length > 0 )) {


### PR DESCRIPTION
Fixes this issue:
![image](https://user-images.githubusercontent.com/44113229/125217576-62174a80-e304-11eb-9dcc-6006228dac2c.png)

The issue was caused by turbolinks saving a copy of the page (including the table) in cache which is then used when the page is revisited. However, our table initialisation is triggered by the `turbolinks:load` event which fires every time the page is visited, causing the table to be initialised again even though one copy was already saved in cache.

The first part of the solution destroys the table using the `turbolinks:before-cache` event but this causes the table width to shrink on every [restoration visit](https://github.com/turbolinks/turbolinks#restoration-visits) (using browser back/forward buttons).

The table's `bAutoWidth` was set to false to deal with this new problem. While the table no longer shrinks on every visit, the column width (and thus table width) seems to vary based on the content of the table.

See also:
https://github.com/turbolinks/turbolinks#understanding-caching
https://github.com/turbolinks/turbolinks/issues/106