### PR TITLE
Add Eligibility Requirements to All Challenge Panels

### DIFF
--- a/app/views/challenges/_challenge_panel.erb
+++ b/app/views/challenges/_challenge_panel.erb
@@ -4,6 +4,12 @@
     <% unless challenge.short_desc.blank? %>
       <h5><%= challenge.short_desc %></h5>
     <% end %>
+    <% if challenge.eligibility.present? && @competition.current %>
+      <p>
+        <strong>Eligibility:</strong>
+        <%= challenge.eligibility %>
+      </p>
+    <% end %>
     <p>
       <%= link_to 'Go to Challenge', challenge_path(challenge.identifier) %>
       | <%= pluralize entry_count, 'team has', plural: 'teams have'  %>


### PR DESCRIPTION
## Background

Eligibility requirements need to be available to anyone browsing challenges in a competition year.

![Screen Shot 2021-07-16 at 9 06 26 pm](https://user-images.githubusercontent.com/4644609/125938562-4710d126-a21f-4c29-9fbd-5cf8d3538856.png)