### PR TITLE
Redo Sponsorship Position

### DIFF
--- a/app/controllers/admin/regions/events_controller.rb
+++ b/app/controllers/admin/regions/events_controller.rb
@@ -17,7 +17,7 @@ class Admin::Regions::EventsController < ApplicationController
   def preview
     @event = Event.find params[:id]
     @event_partners = @event.event_partners
-    @sponsorship_types = @region.sponsorship_types.distinct.order order: :asc
+    @sponsorship_types = @region.sponsorship_types.distinct.order position: :asc
     @user = current_user
     @event_assignment = @user.event_assignment(@competition)
     @registration = Registration.find_by(

--- a/app/controllers/admin/sponsorship_types_controller.rb
+++ b/app/controllers/admin/sponsorship_types_controller.rb
@@ -11,7 +11,7 @@ class Admin::SponsorshipTypesController < ApplicationController
   end
 
   def create
-    create_new_sponsorship_type
+    @sponsorship_type = @competition.sponsorship_types.new(sponsorship_type_params)
     if @sponsorship_type.save
       flash[:notice] = 'New Sponsorship Type Created'
       redirect_to admin_competition_sponsorship_types_path @competition
@@ -26,7 +26,7 @@ class Admin::SponsorshipTypesController < ApplicationController
   end
 
   def update
-    update_sponsorship_type
+    @sponsorship_type = SponsorshipType.find params[:id]
     if @sponsorship_type.update sponsorship_type_params
       flash[:notice] = 'Sponsorship Type Updated'
       redirect_to admin_competition_sponsorship_types_path @competition
@@ -48,17 +48,5 @@ class Admin::SponsorshipTypesController < ApplicationController
 
     flash[:alert] = 'You must have valid assignments to access this section.'
     redirect_to root_path
-  end
-
-  def create_new_sponsorship_type
-    SponsorshipType.reorder_from params[:sponsorship_type][:position].to_i
-    @sponsorship_type = @competition.sponsorship_types.new(
-      sponsorship_type_params
-    )
-  end
-
-  def update_sponsorship_type
-    SponsorshipType.reorder_from params[:sponsorship_type][:position].to_i
-    @sponsorship_type = SponsorshipType.find params[:id]
   end
 end

--- a/app/controllers/admin/sponsorship_types_controller.rb
+++ b/app/controllers/admin/sponsorship_types_controller.rb
@@ -2,7 +2,7 @@ class Admin::SponsorshipTypesController < ApplicationController
   before_action :authenticate_user!, :check_for_privileges
 
   def index
-    @sponsorship_types = @competition.sponsorship_types.order order: :asc
+    @sponsorship_types = @competition.sponsorship_types.order position: :asc
     @admin_privileges = current_user.admin_privileges? @competition
   end
 
@@ -39,7 +39,7 @@ class Admin::SponsorshipTypesController < ApplicationController
   private
 
   def sponsorship_type_params
-    params.require(:sponsorship_type).permit :name, :order
+    params.require(:sponsorship_type).permit :name, :position
   end
 
   def check_for_privileges
@@ -51,14 +51,14 @@ class Admin::SponsorshipTypesController < ApplicationController
   end
 
   def create_new_sponsorship_type
-    SponsorshipType.reorder_from params[:sponsorship_type][:order].to_i
+    SponsorshipType.reorder_from params[:sponsorship_type][:position].to_i
     @sponsorship_type = @competition.sponsorship_types.new(
       sponsorship_type_params
     )
   end
 
   def update_sponsorship_type
-    SponsorshipType.reorder_from params[:sponsorship_type][:order].to_i
+    SponsorshipType.reorder_from params[:sponsorship_type][:position].to_i
     @sponsorship_type = SponsorshipType.find params[:id]
   end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -12,7 +12,7 @@ class EventsController < ApplicationController
   def show
     @event_partners = @event.event_partners
     @region = @event.region
-    @sponsorship_types = @region.sponsorship_types.distinct.order order: :asc
+    @sponsorship_types = @region.sponsorship_types.distinct.order position: :asc
     set_signed_in_user_vars if user_signed_in?
   end
 

--- a/app/models/sponsorship_type.rb
+++ b/app/models/sponsorship_type.rb
@@ -4,19 +4,19 @@ class SponsorshipType < ApplicationRecord
   has_many :sponsorships, dependent: :destroy
   has_many :sponsors, through: :sponsorships
 
-  validates :name, :order, presence: true
+  validates :name, :position, presence: true
 
-  # Reorders the Sponsorship types that have been displaced when the order
+  # Reorders the Sponsorship types that have been displaced when the position
   # attribute is changed.
   # ENHANCEMENT: Add to a callback?
   # ENHANCEMENT: Add a validation to inforce?
   def self.reorder_from(from)
     placeholder = from
-    all.order(order: :asc).each do |type|
-      next if type.order < placeholder
-      break if type.order != placeholder
+    all.order(position: :asc).each do |sponsorship_type|
+      next if sponsorship_type.position < placeholder
+      break if sponsorship_type.position != placeholder
 
-      type.update(order: placeholder += 1)
+      sponsorship_type.update(position: placeholder += 1)
     end
   end
 end

--- a/app/views/admin/sponsorship_types/_form.html.erb
+++ b/app/views/admin/sponsorship_types/_form.html.erb
@@ -4,8 +4,8 @@
     <%= f.text_field :name, class: "form-control" %>
   </div>
   <div class="form-group">
-    <%= f.label :order %>
-    <%= f.number_field :order, min: 1 %>
+    <%= f.label :position %>
+    <%= f.number_field :position, min: 1 %>
   </div>
   <div class="actions">
     <%= f.submit %>

--- a/app/views/admin/sponsorship_types/index.html.erb
+++ b/app/views/admin/sponsorship_types/index.html.erb
@@ -8,7 +8,7 @@
   </p>
   <table class="projects-table" data-turbolinks="false" id="admin-sponsorship-types-table">
     <thead>
-      <th>Order</th>
+      <th>Position</th>
       <th>Name</th>
       <th>Action</th>
     </thead>
@@ -16,7 +16,7 @@
       <% @sponsorship_types.each do |sponsorship_type| %>
         <tr>
           <td>
-            <%= sponsorship_type.order %>
+            <%= sponsorship_type.position %>
           </td>
           <td>
             <%= sponsorship_type.name %>

--- a/db/migrate/20210724052650_rename_sponsorship_type_order.rb
+++ b/db/migrate/20210724052650_rename_sponsorship_type_order.rb
@@ -1,0 +1,5 @@
+class RenameSponsorshipTypeOrder < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :sponsorship_types, :order, :position
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_17_002651) do
+ActiveRecord::Schema.define(version: 2021_07_24_052650) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -428,11 +428,11 @@ ActiveRecord::Schema.define(version: 2021_07_17_002651) do
   create_table "sponsorship_types", force: :cascade do |t|
     t.integer "competition_id"
     t.string "name"
-    t.integer "order"
+    t.integer "position"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["competition_id"], name: "index_sponsorship_types_on_competition_id"
-    t.index ["order"], name: "index_sponsorship_types_on_order"
+    t.index ["position"], name: "index_sponsorship_types_on_position"
   end
 
   create_table "sponsorships", force: :cascade do |t|

--- a/db/seeders/competition_seeder.rb
+++ b/db/seeders/competition_seeder.rb
@@ -102,7 +102,7 @@ class CompetitionSeeder < Seeder
     5.times do |time|
       comp.sponsorship_types.create(
         name: "Tier #{time + 1} #{comp.year}",
-        order: time + 1
+        position: time + 1
       )
     end
 

--- a/test/controllers/admin/sponsorship_types_controller_test.rb
+++ b/test/controllers/admin/sponsorship_types_controller_test.rb
@@ -21,7 +21,7 @@ class Admin::SponsorshipTypesControllerTest < ActionDispatch::IntegrationTest
     assert_difference 'SponsorshipType.count' do
       post admin_competition_sponsorship_types_url(
         @competition, params: {
-          sponsorship_type: { name: 'Example', order: 1 }
+          sponsorship_type: { name: 'Example', position: 1 }
         }
       )
     end
@@ -32,7 +32,7 @@ class Admin::SponsorshipTypesControllerTest < ActionDispatch::IntegrationTest
     assert_no_difference 'SponsorshipType.count' do
       post admin_competition_sponsorship_types_url(
         @competition, params: {
-          sponsorship_type: { name: 'Example', order: nil }
+          sponsorship_type: { name: 'Example', position: nil }
         }
       )
     end

--- a/test/fixtures/sponsorship_types.yml
+++ b/test/fixtures/sponsorship_types.yml
@@ -8,10 +8,10 @@ one:
   id: 1
   competition_id: 1
   name: Gold Sponsor
-  order: 1
+  position: 1
 #
 two:
   id: 2
   competition_id: 1
   name: Silver Sponsor
-  order: 2
+  position: 2

--- a/test/fixtures/sponsorship_types.yml
+++ b/test/fixtures/sponsorship_types.yml
@@ -14,4 +14,4 @@ two:
   id: 2
   competition_id: 1
   name: Silver Sponsor
-  position: 2
+  position: 4

--- a/test/models/sponsorship_type_test.rb
+++ b/test/models/sponsorship_type_test.rb
@@ -14,7 +14,7 @@ class SponsorshipTypeTest < ActiveSupport::TestCase
   end
 
   test 'sponsorship type validations' do
-    assert_not SponsorshipType.new(name: 'example', order: nil).save
-    assert_not SponsorshipType.new(name: nil, order: 1).save
+    assert_not SponsorshipType.new(name: 'example', position: nil).save
+    assert_not SponsorshipType.new(name: nil, position: 1).save
   end
 end

--- a/test/models/sponsorship_type_test.rb
+++ b/test/models/sponsorship_type_test.rb
@@ -14,7 +14,14 @@ class SponsorshipTypeTest < ActiveSupport::TestCase
   end
 
   test 'sponsorship type validations' do
-    assert_not SponsorshipType.new(name: 'example', position: nil).save
-    assert_not SponsorshipType.new(name: nil, position: 1).save
+    assert_not @competition.sponsorship_types.new(name: 'example', position: nil).save
+    assert_not @competition.sponsorship_types.new(name: nil, position: 1).save
+  end
+
+  test 'make_a_space validation' do
+    @competition.sponsorship_types.new(name: 'Paladium', position: 1).save!
+
+    assert_equal 2, @sponsorship_type.reload.position
+    assert_equal 4, sponsorship_types(:two).reload.position 
   end
 end


### PR DESCRIPTION
Bit of a refactor in preparation for making the resources self service.

Found a harmless bug: Sponsorship Type positions were shuffled every time a new competition was made 😅

2021 Comp...
![Screen Shot 2021-07-24 at 8 01 08 pm](https://user-images.githubusercontent.com/4644609/126865049-eb940e78-b135-4257-af35-8174f610f983.png)

2020 Comp...
![Screen Shot 2021-07-24 at 8 01 51 pm](https://user-images.githubusercontent.com/4644609/126865068-56df8371-2be3-44e5-9685-1a5da798714c.png)
