### PR TITLE
Move Resources YAML Records to DB

### DIFF
--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -1,11 +1,14 @@
 class ResourcesController < ApplicationController
-  def index; end
+  def index
+    @any_tech = @competition.resources.tech.any?
+    @any_data_portals = @competition.resources.data_portal.any?
+  end
 
   def data_portals
-    @data_portals = YAML.load_file "#{Rails.root}/app/views/resources/data_portals.yml"
+    @data_portals = @competition.resources.data_portal.order(position: :asc)
   end
 
   def tech
-    @tech = YAML.load_file "#{Rails.root}/app/views/resources/tech.yml"
+    @tech = @competition.resources.tech.order(position: :asc)
   end
 end

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -2,7 +2,7 @@ class Competition < ApplicationRecord
   has_many :assignments, as: :assignable
   has_many :holders, dependent: :destroy
   has_many :users, through: :holders
-  has_many :profiles, through: :users 
+  has_many :profiles, through: :users
   has_many :regions
   has_many :sponsors
   has_many :sponsorship_types
@@ -29,6 +29,7 @@ class Competition < ApplicationRecord
   has_many :hunt_questions
   has_many :data_sets, through: :regions
   has_many :badges
+  has_many :resources, dependent: :destroy
 
   has_many :criteria
   has_many :project_criteria, -> { where category: PROJECT }, class_name: 'Criterion'

--- a/app/models/concerns/position.rb
+++ b/app/models/concerns/position.rb
@@ -1,0 +1,27 @@
+module Position
+  extend ActiveSupport::Concern
+
+  included do
+    before_validation :make_a_space!
+  end
+
+  private
+
+  def make_a_space!
+    ActiveRecord::Base.transaction { candidates_to_update.each(&:save!) }
+  end
+
+  def candidates_to_update
+    counter = position
+    candidates_to_reposition.select do |instance|
+      next false unless instance.position == counter
+
+      counter += 1
+      instance.position = counter
+    end
+  end
+
+  def candidates_to_reposition
+    raise 'Need to define a collection of records to update'
+  end
+end

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -1,0 +1,26 @@
+class Resource < ApplicationRecord
+  include Position
+
+  belongs_to :competition
+
+  validates :category, :position, :name, :url, :short_url, presence: true
+  validates :position, :name, uniqueness: { scope: %i[competition_id category],
+    message: 'already taken in this competition' }
+
+  enum category: {
+    data_portal: 0,
+    tech: 1
+  }
+
+  private
+
+  def candidates_to_reposition
+    return [] if competition.nil?
+
+    competition.resources
+      .where(category: category)
+      .where(position: position..)
+      .where.not(id: self)
+      .order(position: :asc)
+  end
+end

--- a/app/models/sponsorship_type.rb
+++ b/app/models/sponsorship_type.rb
@@ -1,10 +1,10 @@
 class SponsorshipType < ApplicationRecord
+  include Position
+
   belongs_to :competition
 
   has_many :sponsorships, dependent: :destroy
   has_many :sponsors, through: :sponsorships
-
-  before_validation :make_a_space!
 
   validates :name, :position, presence: true
   validates :position, uniqueness: { scope: :competition_id,
@@ -12,21 +12,7 @@ class SponsorshipType < ApplicationRecord
 
   private
 
-  def make_a_space!
-    SponsorshipType.transaction { candidates_to_update.each(&:save!) }
-  end
-
-  def candidates_to_update
-    counter = position
-    candidates_to_consider.select do |sponsorship_type|
-      next false unless sponsorship_type.position == counter
-
-      counter += 1
-      sponsorship_type.position = counter
-    end
-  end
-
-  def candidates_to_consider
+  def candidates_to_reposition
     return [] if competition.nil?
 
     competition.sponsorship_types

--- a/app/views/resources/data_portals.erb
+++ b/app/views/resources/data_portals.erb
@@ -5,10 +5,10 @@
   </h2>
   <section class="dataportals">
     <% @data_portals.each do |resource| %>
-      <%= render 'resource_tile',  
-        url: resource['url'],      
-        name: resource['name'],      
-        short_url: resource['short_url']
+      <%= render 'resource_tile',
+        url: resource.url,
+        name: resource.name,
+        short_url: resource.short_url
        %>
     <% end %>
   </section>

--- a/app/views/resources/index.erb
+++ b/app/views/resources/index.erb
@@ -4,12 +4,14 @@
     <%= yield :title %>
   </h2>
   <section class="dataportals">
-    <%= link_to data_portals_resources_path do %>
-      <article>
-        <div>
-          <h3>Data Portals</h3>
-        </div>
-      </article>
+    <% if @any_data_portals %>
+      <%= link_to data_portals_resources_path do %>
+        <article>
+          <div>
+            <h3>Data Portals</h3>
+          </div>
+        </article>
+      <% end %>
     <% end %>
     <%= link_to data_sets_path do %>
       <article class="resource_tile">
@@ -18,7 +20,7 @@
         </div>
       </article>
     <% end %>
-    <% if @competition.year == 2020 %>
+    <% if @any_tech %>
       <%= link_to tech_resources_path do %>
         <article>
           <div>
@@ -26,6 +28,8 @@
           </div>
         </article>
       <% end %>
+    <% end %>
+    <% if @competition.year == 2020 %>
       <%= link_to 'https://govhack.org/lifehacks/', target: '_blank' do %>
         <article>
           <div>

--- a/app/views/resources/tech.erb
+++ b/app/views/resources/tech.erb
@@ -5,10 +5,10 @@
   </h2>
   <section class="dataportals">
     <% @tech.each do |resource| %>
-      <%= render 'resource_tile',    
-        url: resource['url'],         
-        name: resource['name'],    
-        short_url: resource['short_url']
+      <%= render 'resource_tile',
+        url: resource.url,
+        name: resource.name,
+        short_url: resource.short_url
       %>
     <% end %>
   </section>

--- a/db/migrate/20210724100750_create_resources.rb
+++ b/db/migrate/20210724100750_create_resources.rb
@@ -1,0 +1,36 @@
+class CreateResources < ActiveRecord::Migration[6.1]
+  def change
+    create_table :resources do |t|
+      t.integer :competition_id
+      t.integer :category
+      t.integer :position
+      t.string :url
+      t.string :name
+      t.string :short_url
+
+      t.timestamps
+    end
+
+    competition = Competition.find_by_year 2020
+
+    data_portals = YAML.load_file "#{Rails.root}/app/views/resources/data_portals.yml"
+    data_portals.each_with_index do |data_portal_hash, index|
+      competition.resources.data_portal.create!(
+        position: index + 1,
+        name: data_portal_hash['name'],
+        url: data_portal_hash['url'],
+        short_url: data_portal_hash['short_url']
+      )
+    end
+
+    tech = YAML.load_file "#{Rails.root}/app/views/resources/tech.yml"
+    tech.each_with_index do |tech_hash, index|
+      competition.resources.tech.create!(
+        position: index + 1,
+        name: tech_hash['name'],
+        url: tech_hash['url'],
+        short_url: tech_hash['short_url']
+      )
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_24_052650) do
+ActiveRecord::Schema.define(version: 2021_07_24_100750) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -403,6 +403,17 @@ ActiveRecord::Schema.define(version: 2021_07_24_052650) do
     t.index ["event_id"], name: "index_registrations_on_event_id"
     t.index ["holder_id"], name: "index_registrations_on_holder_id"
     t.index ["status"], name: "index_registrations_on_status"
+  end
+
+  create_table "resources", force: :cascade do |t|
+    t.integer "competition_id"
+    t.integer "category"
+    t.integer "position"
+    t.string "url"
+    t.string "name"
+    t.string "short_url"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "scores", force: :cascade do |t|

--- a/db/seeders/competition_seeder.rb
+++ b/db/seeders/competition_seeder.rb
@@ -117,6 +117,25 @@ class CompetitionSeeder < Seeder
         )
       end
     end
+
+    5.times do |time|
+      comp.resources.tech.create!(
+        position: time,
+        name: "Tech #{time}",
+        url: "www.tech#{time}.com",
+        short_url: "tech.#{time}"
+      )
+    end
+
+    20.times do |time|
+      comp.resources.data_portal.create!(
+        position: time,
+        name: "Data Portal #{time}",
+        url: "www.data_portal#{time}.com",
+        short_url: "data_portal.#{time}"
+      )
+    end
+
     comp.update hunt_badge: comp.badges.sample
 
     Faker::Color.unique.clear

--- a/test/fixtures/resources.yml
+++ b/test/fixtures/resources.yml
@@ -1,0 +1,24 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one:
+  id: 1
+  competition_id: 1
+  position: 1
+  category: 0
+  name: resource 1
+  url: www.url1.com
+  short_url: url1
+
+#
+two:
+  id: 2
+  competition_id: 1
+  position: 1
+  category: 1
+  name: resource 2
+  url: www.url2.com
+  short_url: url2

--- a/test/models/competition_test.rb
+++ b/test/models/competition_test.rb
@@ -27,38 +27,31 @@ class CompetitionTest < ActiveSupport::TestCase
     @old_competition = @competition
     @new_competition = Competition.second
     @event_assignment = Assignment.fourth
-    @user = users(:one)
-    @profile = profiles(:one)
+  end
+
+  test 'direct competition associations' do
+    assert @competition.project_criteria.include? @project_criterion
+    assert @competition.challenge_criteria.include? @challenge_criterion
+    assert @competition.hunt_questions.include? hunt_questions(:one)
+    assert @competition.badges.include? badges(:one)
+    assert @competition.criteria.include? @criterion
+    assert_includes @competition.resources, resources(:one)
+    assert @competition.sponsorship_types.include? @sponsorship_type
+    assert @competition.regions.include? @region
+    assert @competition.sponsors.include? @sponsor
+    assert @competition.checkpoints.include? @checkpoint
   end
 
   test 'competition associations' do
     assert @competition.assignments.include? @assignment
-    assert @competition.regions.include? @region
-    assert @competition.sponsors.include? @sponsor
-    assert @competition.sponsorship_types.include? @sponsorship_type
-    assert @competition.events.include? @event
-    assert @competition.users.include? @user
-    assert @competition.profiles.include? @profile
-    assert @competition.connection_events.include? @connection_event
-    assert @competition.connection_registrations.include? @connection_registration
-    assert @competition.conference_events.include? events :conference
-    assert @competition.conference_registrations.include? registrations :conference_registration
-    assert @competition.competition_events.include? @competition_event
-    assert @competition.competition_registrations.include? @competition_registration
-    assert @competition.award_events.include? @award_event
-    assert @competition.award_registrations.include? @award_registration
+    assert @competition.users.include? users(:one)
+    assert @competition.profiles.include? profiles(:one)
     assert @competition.teams.include? @team
     assert @competition.projects.include? @project
     assert @competition.team_data_sets.include? @team_data_set
     assert @competition.challenges.include? @challenge
     assert @competition.entries.include? @entry
-    assert @competition.checkpoints.include? @checkpoint
-    assert @competition.hunt_questions.include? hunt_questions(:one)
     assert @competition.data_sets.include? @data_set
-    assert @competition.badges.include? badges(:one)
-    assert @competition.criteria.include? @criterion
-    assert @competition.project_criteria.include? @project_criterion
-    assert @competition.challenge_criteria.include? @challenge_criterion
     assert @competition.competition_assignments.include? @assignment
   end
 
@@ -72,6 +65,12 @@ class CompetitionTest < ActiveSupport::TestCase
     assert @competition.competition_registrations.include? @competition_registration
     assert @competition.award_events.include? @award_event
     assert @competition.award_registrations.include? @award_registration
+  end
+
+  test 'dependent destroy' do
+    @competition.destroy!
+
+    assert_raises(ActiveRecord::RecordNotFound) { resources(:one).reload }
   end
 
   test 'competition belongs to associations' do

--- a/test/models/resource_test.rb
+++ b/test/models/resource_test.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+
+class ResourceTest < ActiveSupport::TestCase
+  setup do
+    @resource = resources(:one)
+    @competition = competitions(:one)
+  end
+
+  test 'resources associations' do
+    assert_equal @competition, @resource.competition
+  end
+
+  test 'resources validations presence' do
+    %i[category position name url short_url].each do |attribute|
+      attributes = {
+        category: :data_portal,
+        position: 1,
+        name: 'New Name',
+        url: 'www.new.com',
+        short_url: 'new'
+      }
+      attributes[attribute] = nil
+      resource = competitions(:two).resources.new(attributes)
+      assert_raises(ActiveRecord::RecordInvalid) { resource.save! }
+    end
+  end
+
+  test 'resources validations uniqueness' do
+    resource_two = resources(:two)
+    assert_raises(ActiveRecord::RecordInvalid) do
+      @resource.update! name: resource_two.name, category: resource_two.category
+    end
+  end
+
+  test 'position validation' do
+    @competition.resources.data_portal.new(
+      position: 1,
+      name: 'resource 2',
+      url: 'www.resource.2',
+      short_url: 'resourcee.2'
+    ).save!
+
+    assert_equal 2, @resource.reload.position
+  end
+end

--- a/test/models/sponsorship_type_test.rb
+++ b/test/models/sponsorship_type_test.rb
@@ -18,10 +18,10 @@ class SponsorshipTypeTest < ActiveSupport::TestCase
     assert_not @competition.sponsorship_types.new(name: nil, position: 1).save
   end
 
-  test 'make_a_space validation' do
+  test 'position validation' do
     @competition.sponsorship_types.new(name: 'Paladium', position: 1).save!
 
     assert_equal 2, @sponsorship_type.reload.position
-    assert_equal 4, sponsorship_types(:two).reload.position 
+    assert_equal 4, sponsorship_types(:two).reload.position
   end
 end


### PR DESCRIPTION
## Background

Previously entities in Resources such as Data Portals and Tech had to be added through code changes and PRs

Moving the data into the DB and out of yaml files take us most of the way to getting to self service.