### PR TITLE
Accept Code of Conduct before Publishing Profile

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -16,12 +16,16 @@ class ProfilesController < ApplicationController
     @joined_published_projects = @user.joined_published_projects.joins(:competition).where(competitions: {id: @competition.id})
   end
 
-  def edit; end
+  def edit
+    @user = current_user
+  end
 
   def update
+    check_code_of_conduct
     if @profile.update(profile_params)
       redirect_to profile_path(@profile), notice: 'Your Profile has been updated'
     else
+      @user = current_user
       flash[:alert] = @profile.errors.full_messages.to_sentence
       render :edit
     end
@@ -64,5 +68,11 @@ class ProfilesController < ApplicationController
     end
 
     redirect_to profiles_path, alert: 'This Profile has not been published yet'
+  end
+
+  def check_code_of_conduct
+    return unless params[:accepted_code_of_conduct] == 'true'
+
+    current_user.update accepted_code_of_conduct: Time.now.in_time_zone(COMP_TIME_ZONE)
   end
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -6,6 +6,8 @@ class Profile < ApplicationRecord
 
   validates :identifier, uniqueness: true, allow_nil: true
 
+  validate :accept_code_of_conduct_before_publish
+
   acts_as_taggable_on :skills, :interests
 
   has_one_attached :profile_picture
@@ -77,5 +79,15 @@ class Profile < ApplicationRecord
     return new_identifier unless Profile.where(identifier: new_identifier).where.not(id: id).exists?
 
     uri_pritty "#{new_identifier}-#{id}"
+  end
+
+  private
+
+  def accept_code_of_conduct_before_publish
+    return unless published
+
+    return if user.accepted_code_of_conduct
+
+    errors.add :user, 'please agree to the Code of Conduct'
   end
 end

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -124,6 +124,6 @@ class Registration < ApplicationRecord
   def check_code_of_conduct
     return if assignment_id.nil? || user.accepted_code_of_conduct
 
-    errors.add :user, 'The Code of Conduct must be agreed to.'
+    errors.add :user, 'please agree to the Code of Conduct'
   end
 end

--- a/app/views/profiles/edit.erb
+++ b/app/views/profiles/edit.erb
@@ -55,6 +55,7 @@
           <%= form.text_field :interest_list, value: @profile.interest_list&.join(', '), class: 'form-control' %>
           <small>Separate tags with commas</small>
         </div>
+        <%= render 'registrations/agree_to_code_of_conduct' %>
         <div class="actions">
           <%= form.submit (@profile.published ? 'Update' : 'Publish') %>
         </div>

--- a/db/migrate/20210805115752_unpublish_code_conduct.rb
+++ b/db/migrate/20210805115752_unpublish_code_conduct.rb
@@ -1,0 +1,7 @@
+class UnpublishCodeConduct < ActiveRecord::Migration[6.1]
+  def change
+    User.joins(:profile).where(accepted_code_of_conduct: nil, profiles: {published: true}).preload(:profile).each do |user|
+      user.profile.update! published: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_02_112706) do
+ActiveRecord::Schema.define(version: 2021_08_05_115752) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/test/controllers/profiles_controller_test.rb
+++ b/test/controllers/profiles_controller_test.rb
@@ -60,4 +60,13 @@ class ProfilesControllerTest < ActionDispatch::IntegrationTest
     @profile.reload
     assert @profile.team_status != old_team_status
   end
+
+  test 'should patch update fail' do
+    sign_in users :one
+    users(:one).update! accepted_code_of_conduct: nil
+    patch profile_path @profile, params: {
+      profile: { team_status: 'Team Full' }
+    }
+    assert_response :success
+  end
 end

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -41,4 +41,12 @@ class ProfileTest < ActiveSupport::TestCase
     @profile.reload
     assert @profile.identifier == 'example_name'
   end
+
+  test 'accept_code_of_conduct_before_publish' do
+    @user.update! accepted_code_of_conduct: false
+
+    assert_raises(ActiveRecord::RecordInvalid) do
+      @profile.update!(published: true)
+    end
+  end
 end


### PR DESCRIPTION
## Background

Previously it was possible to publish a profile without accepting the code of conduct.
