### PR TITLE
Fix docker deployment and hot reloading issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ gem 'bundler-audit'
 # A tagging plugin that allows for custom tagging along dynamic contexts.
 gem 'acts-as-taggable-on', '~> 7.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes
-gem 'mini_racer', platforms: :ruby
+gem 'mini_racer', '< 0.5.0', platforms: :ruby
 # Bootstrap 4 ruby gem for Ruby on Rails (Sprockets) and Hanami (formerly Lotus).
 gem 'bootstrap', '~> 4.5.0'
 # This gem provides only Free icons from Font-Awesome.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,8 +190,9 @@ GEM
       addressable (~> 2.7)
     letter_opener (1.8.1)
       launchy (>= 2.2, < 3)
-    libv8-node (16.10.0.0-x86_64-darwin)
-    libv8-node (16.10.0.0-x86_64-linux)
+    libv8-node (15.14.0.1-x86_64-darwin-20)
+    libv8-node (15.14.0.1-x86_64-darwin-21)
+    libv8-node (15.14.0.1-x86_64-linux)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -206,8 +207,8 @@ GEM
     matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
-    mini_racer (0.6.2)
-      libv8-node (~> 16.10.0.0)
+    mini_racer (0.4.0)
+      libv8-node (~> 15.14.0.0)
     minitest (5.16.0)
     mocha (1.14.0)
     msgpack (1.5.2)
@@ -411,7 +412,7 @@ DEPENDENCIES
   jquery-rails
   letter_opener
   listen (>= 3.0.5, < 3.2)
-  mini_racer
+  mini_racer (< 0.5.0)
   mocha
   omniauth-google-oauth2
   omniauth-rails_csrf_protection

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -59,7 +59,7 @@
           <% end %>
           <br />
           <% if @event_partners.present? %>
-            <h3><%= pluralize @event_partners.count, 'Event Partner' %></h3>
+            <h3><%= 'Event Partner'.pluralize(@event_partners.count) %></h3>
             <br />
             <% @event_partners.each do |event_partner| %>
               <div class="clickable_tile">

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -77,7 +77,7 @@ Rails.application.configure do
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
-  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  config.file_watcher = ActiveSupport::FileUpdateChecker
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,19 +3,24 @@ version: '3.1'
 services:
 
   hackerspace3:
-    image: govhackau/hackerspace3
     build: .
+    depends_on:
+      - postgres
     env_file: .env
+    image: govhackau/hackerspace3
     ports:
-      - 3000:3000
-    restart: always
+      - "3000:3000"
+    restart: on-failure
+    volumes:
+      - ./:/usr/src/app
 
   postgres:
-    image: postgres:12.1
     env_file: .env
+    image: postgres:12.1
+    ports:
+      - "5432:5432"
     volumes:
       - pg_db:/var/lib/postgresql/data
-    restart: always
 
 volumes:
   pg_db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ services:
     image: govhackau/hackerspace3
     ports:
       - "3000:3000"
-    restart: on-failure
     volumes:
       - ./:/usr/src/app
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 set -e
 
+if [ -f /usr/src/app/tmp/pids/server.pid ]; then
+  rm /usr/src/app/tmp/pids/server.pid
+fi
+
 # Initialise Rails database if it doesn't already exist
 if ! rails db:version >/dev/null 2>&1
 then


### PR DESCRIPTION
This change adds configurations to allow hot reloading when using docker. It also downgrades the `mini_racer` gem, which was causing docker build failures. This will obviously incur tech debt, as the gem should be updated at some point in the future and any resulting problems with docker should be fixed.