### PR TITLE
Fix navbar link spacing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ gem 'bundler-audit'
 # A tagging plugin that allows for custom tagging along dynamic contexts.
 gem 'acts-as-taggable-on', '~> 7.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes
-gem 'mini_racer', platforms: :ruby
+gem 'mini_racer', '< 0.5.0', platforms: :ruby
 # Bootstrap 4 ruby gem for Ruby on Rails (Sprockets) and Hanami (formerly Lotus).
 gem 'bootstrap', '~> 4.5.0'
 # This gem provides only Free icons from Font-Awesome.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,9 +190,10 @@ GEM
       addressable (~> 2.7)
     letter_opener (1.8.1)
       launchy (>= 2.2, < 3)
-    libv8-node (16.10.0.0-x86_64-darwin)
-    libv8-node (16.10.0.0-x86_64-linux)
-    listen (3.0.8)
+    libv8-node (15.14.0.1-x86_64-darwin-20)
+    libv8-node (15.14.0.1-x86_64-darwin-21)
+    libv8-node (15.14.0.1-x86_64-linux)
+    listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     loofah (2.18.0)
@@ -205,9 +206,9 @@ GEM
     matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
-    mini_racer (0.6.2)
-      libv8-node (~> 16.10.0.0)
-    minitest (5.16.1)
+    mini_racer (0.4.0)
+      libv8-node (~> 15.14.0.0)
+    minitest (5.16.0)
     mocha (1.14.0)
     msgpack (1.5.2)
     multi_json (1.15.0)
@@ -408,7 +409,7 @@ DEPENDENCIES
   jquery-rails
   letter_opener
   listen (>= 3.0.5, < 3.2)
-  mini_racer
+  mini_racer (< 0.5.0)
   mocha
   omniauth-google-oauth2
   omniauth-rails_csrf_protection

--- a/app/assets/stylesheets/components/top_nav_bar.scss
+++ b/app/assets/stylesheets/components/top_nav_bar.scss
@@ -38,3 +38,7 @@
     display: block;
   }
 }
+
+.topbar-link {
+  padding: 0.1em 0 !important;
+}

--- a/app/assets/stylesheets/components/top_nav_bar.scss
+++ b/app/assets/stylesheets/components/top_nav_bar.scss
@@ -39,6 +39,6 @@
   }
 }
 
-.topbar-link {
+.navbar-link {
   padding: 0.1em 0 !important;
 }

--- a/app/views/shared/_top_bar.html.erb
+++ b/app/views/shared/_top_bar.html.erb
@@ -12,19 +12,19 @@
       <div class="navbar-collapse hackerspace-collapse">
         <ul class="nav navbar-nav hackerspace-nav">
           <li>
-            <%= link_to 'Events', events_path, class: "topbar-link" %>
+            <%= link_to 'Events', events_path, class: "navbar-link" %>
           </li>
           <li>
-            <%= link_to 'Challenges', challenges_path, class: "topbar-link" %>
+            <%= link_to 'Challenges', challenges_path, class: "navbar-link" %>
           </li>
           <li>
-            <%= link_to 'Projects', projects_path, class: "topbar-link" %>
+            <%= link_to 'Projects', projects_path, class: "navbar-link" %>
           </li>
           <li>
-            <%= link_to 'Profiles', profiles_path, class: "topbar-link" %>
+            <%= link_to 'Profiles', profiles_path, class: "navbar-link" %>
           </li>
           <li>
-            <%= link_to 'Resources', resources_path, class: "topbar-link" %>
+            <%= link_to 'Resources', resources_path, class: "navbar-link" %>
           </li>
         </ul>
         <div class="nav navbar-nav hackerspace-nav navbar-right">

--- a/app/views/shared/_top_bar.html.erb
+++ b/app/views/shared/_top_bar.html.erb
@@ -12,19 +12,19 @@
       <div class="navbar-collapse hackerspace-collapse">
         <ul class="nav navbar-nav hackerspace-nav">
           <li>
-            <%= link_to 'Events', events_path %>
+            <%= link_to 'Events', events_path, class: "topbar-link" %>
           </li>
           <li>
-            <%= link_to 'Challenges', challenges_path %>
+            <%= link_to 'Challenges', challenges_path, class: "topbar-link" %>
           </li>
           <li>
-            <%= link_to 'Projects', projects_path %>
+            <%= link_to 'Projects', projects_path, class: "topbar-link" %>
           </li>
           <li>
-            <%= link_to 'Profiles', profiles_path %>
+            <%= link_to 'Profiles', profiles_path, class: "topbar-link" %>
           </li>
           <li>
-            <%= link_to 'Resources', resources_path %>
+            <%= link_to 'Resources', resources_path, class: "topbar-link" %>
           </li>
         </ul>
         <div class="nav navbar-nav hackerspace-nav navbar-right">

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -77,7 +77,7 @@ Rails.application.configure do
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
-  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  config.file_watcher = ActiveSupport::FileUpdateChecker
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ services:
     image: govhackau/hackerspace3
     ports:
       - "3000:3000"
-    restart: on-failure
     volumes:
       - ./:/usr/src/app
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,13 +9,16 @@ services:
     env_file: .env
     image: govhackau/hackerspace3
     ports:
-      - 3000:3000
+      - "3000:3000"
+    restart: on-failure
     volumes:
       - ./:/usr/src/app
 
   postgres:
     env_file: .env
     image: postgres:12.1
+    ports:
+      - "5432:5432"
     volumes:
       - pg_db:/var/lib/postgresql/data
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 set -e
 
+if [ -f /usr/src/app/tmp/pids/server.pid ]; then
+  rm /usr/src/app/tmp/pids/server.pid
+fi
+
 # Initialise Rails database if it doesn't already exist
 if ! rails db:version >/dev/null 2>&1
 then


### PR DESCRIPTION
This change reduces the spacing for navbar links between the word and the red underline.

The existing styling was from the padding rule in `app\assets\stylesheets\components\hackerspace_collapse.scss:20` for all anchor (`<a>`) tags, but changing that value would affect the padding for all anchor tags. For this reason, a `navbar-link` class has been created which applies to only the navbar anchors, and reduces the padding as required.

Manually tested on various screen sizes in-browser, seems to have been applied correctly.

New:
![image](https://user-images.githubusercontent.com/44113229/175305680-2477abe3-4a05-419a-a0c1-aa91ec55c1fc.png)

Old:
![image](https://user-images.githubusercontent.com/44113229/175305750-fd9208ed-51f9-492b-a128-25cf149cb70a.png)
