### PR TITLE
Fix docker and implement hot reloading

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.2
+FROM ruby:3.0.0
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,19 +3,21 @@ version: '3.1'
 services:
 
   hackerspace3:
-    image: govhackau/hackerspace3
     build: .
+    depends_on:
+      - postgres
     env_file: .env
+    image: govhackau/hackerspace3
     ports:
       - 3000:3000
-    restart: always
+    volumes:
+      - ./:/usr/src/app
 
   postgres:
-    image: postgres:12.1
     env_file: .env
+    image: postgres:12.1
     volumes:
       - pg_db:/var/lib/postgresql/data
-    restart: always
 
 volumes:
   pg_db:


### PR DESCRIPTION
This change upgrades the Ruby version in the Dockerfile to `3.0.0`, as well as fixing the line endings in `docker-entrypoint.sh` to `LF` and making small adjustments to `docker-compose.yaml` such as alphabetical ordering.