### PR TITLE
Change login and register button UI

### DIFF
--- a/app/assets/stylesheets/components/navbar_right.scss
+++ b/app/assets/stylesheets/components/navbar_right.scss
@@ -2,7 +2,7 @@
 
   .buttons-group {
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
   }
 
   button {
@@ -11,13 +11,13 @@
 
     .nav-button {
       margin: 3px;
-      border-radius: 0.5em;
+      border-radius: 10em;
       background-color: #c61f55;
       border: 1px solid #c61f55;
       color: #ffffff;
       display: inline-block;
       cursor: pointer;
-      padding: 10px 15px;
+      padding: 10px 40px;
 
       a {
         color: #ffffff;
@@ -31,24 +31,16 @@
     }
 
     .login-button:hover {
-      background-color: #6dbff9;
-      border: 1px solid #6dbff9;
-
-      >a {
-        color: #fff;
-        text-decoration: none;
-      }
+      color: #59baff;
     }
 
     .login-button {
       margin: 3px;
       border-radius: 0.5em;
-      background-color: #4c9ad2;
-      border: 1px solid #4c9ad2;
-      color: #fff;
+      color: #3C7CAB;
       display: inline-block;
       cursor: pointer;
-      padding: 10px 15px;
+      padding: 10px 40px;
 
       a {
         color: #ffffff;
@@ -101,6 +93,11 @@
 
 @media only screen and (max-width: 999px) {
   .navbar-right {
+
+    .buttons-group {
+      flex-direction: column;
+    }
+    
     .nav-button {
       margin: 10px 5px;
     }

--- a/app/views/shared/_session_login_links.html.erb
+++ b/app/views/shared/_session_login_links.html.erb
@@ -8,7 +8,7 @@
   </aside>
 <% else %>
   <div class="buttons-group">
-    <%= link_to 'Sign Up', new_user_registration_path, class: "nav-button" %>
-    <%= link_to "Log In", new_user_session_path , class: "login-button" %>
+    <%= link_to "Sign In", new_user_session_path , class: "login-button" %>
+    <%= link_to 'Register', new_user_registration_path, class: "nav-button" %>
   </div>
 <% end %>


### PR DESCRIPTION
This change updates the `Sign In` and `Register` buttons (previously `Log In` and `Sign Up`) to match the Figma UI designs.

Old design:
![image](https://user-images.githubusercontent.com/44113229/176176657-a348cbd2-6ddb-4bff-8317-b4a2c16764f9.png)

Figma:
![image](https://user-images.githubusercontent.com/44113229/176176557-cc68073b-7557-4a03-9777-7bd1007b5670.png)

New Changes:
![image](https://user-images.githubusercontent.com/44113229/176176732-744b049e-2d8d-4535-a39f-296c2fa4acae.png)

It was decided that for smaller screens, the buttons should remain stacked as they were before, which has been done below:
![image](https://user-images.githubusercontent.com/44113229/176177011-12f7032d-1809-485d-9af0-9e68ab443845.png)