### PR TITLE
Fix Broken Burger in Top Bar Mobile View

### DIFF
--- a/app/views/shared/_top_bar.html.erb
+++ b/app/views/shared/_top_bar.html.erb
@@ -3,7 +3,7 @@
     <div class="container-fluid">
       <div class="navbar-header">
         <%= link_to (render "shared/logo"), root_path %>
-        <button class="navbar-toggle" data-target=".navbar-collapse" data-toggle="collapse" type="button">
+        <button class="navbar-toggle" data-bs-target=".navbar-collapse" data-bs-toggle="collapse" type="button">
           <span></span>
           <span></span>
           <span></span>


### PR DESCRIPTION
Top bar was broken with upgrade from Bootstrap 4-5,

See: [Migrating to v5 - Javascript](https://getbootstrap.com/docs/5.0/migration/#javascript)