### PR TITLE
Expose port 5432 in postgres container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
   postgres:
     env_file: .env
     image: postgres:12.1
+    ports:
+      - "5432"
     volumes:
       - pg_db:/var/lib/postgresql/data
 


### PR DESCRIPTION
This change exposes port `5432` in the `postgres` docker container and binds it to a random host port on container startup. This allows connections with external database client software which helps when development requires database access.