### PR TITLE
Add db migration step to docker-entrypoint.sh

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,11 +1,18 @@
 #!/bin/sh
 set -e
 
+if [ -f /usr/src/app/tmp/pids/server.pid ]; then
+  rm /usr/src/app/tmp/pids/server.pid
+fi
+
 # Initialise Rails database if it doesn't already exist
 if ! rails db:version >/dev/null 2>&1
 then
   echo "Initialising Rails database..."
   rails db:setup
+else
+  echo "Running database migrations..."
+  rails db:migrate
 fi
 
 exec "$@"


### PR DESCRIPTION
Previously, when running through docker, if the database did not exist, it would be created using `db:setup`. However, once the db does exist, there is no provision for running migrations, which leads to an error unless the migrations are run, or the containers are torn down and built up again (which would run `db:setup` again, thus implementing the new migrations anyway).

This change adds a migration step to the `docker-entrypoint.sh` file so that `rails db:migrate` is run if the database exists.