### PR TITLE
Add Content Upload Policy

### DIFF
--- a/app/controllers/concerns/content_policy.rb
+++ b/app/controllers/concerns/content_policy.rb
@@ -1,0 +1,18 @@
+module ContentPolicy
+  extend ActiveSupport::Concern
+
+  class ContentPolicyError < StandardError; end
+
+  private
+
+  def edit_template
+    raise ContentPolicyError, "No edit template defined"
+  end
+
+  def check_content_policy!
+    return if params[:accepted_content_policy]
+
+    flash[:alert] = "Please accept the Govhack's Content Upload Policy"
+    render edit_template
+  end
+end

--- a/app/controllers/profile_pictures_controller.rb
+++ b/app/controllers/profile_pictures_controller.rb
@@ -1,5 +1,8 @@
 class ProfilePicturesController < ApplicationController
+  include ContentPolicy
+
   before_action :authenticate_user!, :profile
+  before_action :check_content_policy!, only: :update
 
   def edit; end
 
@@ -14,6 +17,10 @@ class ProfilePicturesController < ApplicationController
   end
 
   private
+
+  def edit_template
+    :edit
+  end
 
   def profile_params
     params.require(:profile).permit(:profile_picture)

--- a/app/views/profile_pictures/edit.erb
+++ b/app/views/profile_pictures/edit.erb
@@ -14,6 +14,8 @@
           <br>
           <%= form.file_field :profile_picture, accept: 'image/png,image/gif,image/jpeg', required: true %>
         </div>
+        <br>
+        <%= render partial: 'shared/content_policy', locals: { content_type: 'image' } %>
         <div class="actions">
           <%= form.submit 'Upload Image' %>
         </div>

--- a/app/views/shared/_content_policy.html.erb
+++ b/app/views/shared/_content_policy.html.erb
@@ -1,0 +1,4 @@
+<div class="form-group">
+  <%= label_tag :accepted_content_policy, "This #{content_type} adheres to Govhack's #{link_to('Content Upload Policy', "", target: '_blank')}".html_safe %>
+  <%= check_box_tag :accepted_content_policy, 'true', false, required: true %>
+</div>

--- a/test/controllers/profile_pictures_controller_test.rb
+++ b/test/controllers/profile_pictures_controller_test.rb
@@ -10,11 +10,22 @@ class ProfilePicturesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test 'should patch update' do
+  test 'should patch update fail' do
+    picture_path = Rails.root.join('public', 'apple-touch-icon.png')
+    picture = fixture_file_upload(picture_path, 'image/png')
+    assert_no_difference -> { ActiveStorage::Attachment.count } do
+      patch profile_picture_path(profiles(:one)), params: {
+        profile: { profile_picture: picture }
+      }
+    end
+  end
+
+  test 'should patch update success' do
     picture_path = Rails.root.join('public', 'apple-touch-icon.png')
     picture = fixture_file_upload(picture_path, 'image/png')
     assert_difference -> { ActiveStorage::Attachment.count }, 1 do
       patch profile_picture_path(profiles(:one)), params: {
+        accepted_content_policy: true,
         profile: { profile_picture: picture }
       }
     end


### PR DESCRIPTION
This PR adds a checkbox to the Update Profile Picture screen.

The User will need to tick this in order to update their profile picture.

<img width="496" alt="Screen Shot 2022-08-06 at 11 39 49 am" src="https://user-images.githubusercontent.com/4644609/183228664-0a31d7fa-d863-4162-817c-639f7350e11f.png">

