### PR TITLE
Adhoc: Add annotate gem and generate annotations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,7 @@ gem 'bundler-audit'
 gem 'acts-as-taggable-on', '~> 9.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 gem 'mini_racer', platforms: :ruby
-# Bootstrap rubygem for Rails / Sprockets / Hanami / etc 
+# Bootstrap rubygem for Rails / Sprockets / Hanami / etc
 gem 'bootstrap', '~> 5.1.3'
 # This gem provides only Free icons from Font-Awesome.
 gem 'font_awesome5_rails'
@@ -72,6 +72,7 @@ group :development, :test do
 end
 
 group :development do
+  gem "annotate"
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,9 @@ GEM
       activerecord (>= 6.0, < 7.1)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
+    annotate (3.2.0)
+      activerecord (>= 3.2, < 8.0)
+      rake (>= 10.4, < 14.0)
     ast (2.4.2)
     autoprefixer-rails (10.4.7.0)
       execjs (~> 2)
@@ -197,6 +200,7 @@ GEM
       addressable (~> 2.7)
     letter_opener (1.8.1)
       launchy (>= 2.2, < 3)
+    libv8-node (16.10.0.0-arm64-darwin)
     libv8-node (16.10.0.0-x86_64-darwin)
     libv8-node (16.10.0.0-x86_64-linux)
     listen (3.0.8)
@@ -235,6 +239,8 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.8)
+    nokogiri (1.13.8-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.8-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.8-x86_64-linux)
@@ -400,11 +406,13 @@ GEM
     zeitwerk (2.6.0)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES
   acts-as-taggable-on (~> 9.0)
+  annotate
   aws-sdk-s3
   bootsnap (>= 1.1.0)
   bootstrap (~> 5.1.3)

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -3,14 +3,22 @@
 # Table name: assignments
 #
 #  id              :bigint           not null, primary key
-#  user_id         :integer
 #  assignable_type :string
-#  assignable_id   :integer
 #  title           :string
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
+#  assignable_id   :integer
 #  competition_id  :integer
 #  holder_id       :integer
+#  user_id         :integer
+#
+# Indexes
+#
+#  index_assignments_on_assignable_type_and_assignable_id  (assignable_type,assignable_id)
+#  index_assignments_on_competition_id                     (competition_id)
+#  index_assignments_on_holder_id                          (holder_id)
+#  index_assignments_on_title                              (title)
+#  index_assignments_on_user_id                            (user_id)
 #
 class Assignment < ApplicationRecord
   belongs_to :assignable, polymorphic: true

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -1,3 +1,17 @@
+# == Schema Information
+#
+# Table name: assignments
+#
+#  id              :bigint           not null, primary key
+#  user_id         :integer
+#  assignable_type :string
+#  assignable_id   :integer
+#  title           :string
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  competition_id  :integer
+#  holder_id       :integer
+#
 class Assignment < ApplicationRecord
   belongs_to :assignable, polymorphic: true
   belongs_to :holder

--- a/app/models/badge.rb
+++ b/app/models/badge.rb
@@ -3,12 +3,16 @@
 # Table name: badges
 #
 #  id             :bigint           not null, primary key
-#  competition_id :integer
-#  name           :string
-#  identifier     :string
 #  capacity       :integer
+#  identifier     :string
+#  name           :string
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
+#  competition_id :integer
+#
+# Indexes
+#
+#  index_badges_on_identifier  (identifier)
 #
 class Badge < ApplicationRecord
   belongs_to :competition

--- a/app/models/badge.rb
+++ b/app/models/badge.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: badges
+#
+#  id             :bigint           not null, primary key
+#  competition_id :integer
+#  name           :string
+#  identifier     :string
+#  capacity       :integer
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#
 class Badge < ApplicationRecord
   belongs_to :competition
 

--- a/app/models/challenge.rb
+++ b/app/models/challenge.rb
@@ -3,17 +3,24 @@
 # Table name: challenges
 #
 #  id          :bigint           not null, primary key
-#  region_id   :integer
-#  name        :string
-#  short_desc  :text
-#  long_desc   :text
-#  eligibility :text
-#  video_url   :string
 #  approved    :boolean          default(FALSE)
+#  eligibility :text
+#  identifier  :string
+#  long_desc   :text
+#  name        :string
+#  nation_wide :boolean
+#  short_desc  :text
+#  video_url   :string
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
-#  identifier  :string
-#  nation_wide :boolean
+#  region_id   :integer
+#
+# Indexes
+#
+#  index_challenges_on_approved     (approved)
+#  index_challenges_on_identifier   (identifier)
+#  index_challenges_on_nation_wide  (nation_wide)
+#  index_challenges_on_region_id    (region_id)
 #
 class Challenge < ApplicationRecord
   belongs_to :region

--- a/app/models/challenge.rb
+++ b/app/models/challenge.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: challenges
+#
+#  id          :bigint           not null, primary key
+#  region_id   :integer
+#  name        :string
+#  short_desc  :text
+#  long_desc   :text
+#  eligibility :text
+#  video_url   :string
+#  approved    :boolean          default(FALSE)
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  identifier  :string
+#  nation_wide :boolean
+#
 class Challenge < ApplicationRecord
   belongs_to :region
   has_one :competition, through: :region

--- a/app/models/challenge_data_set.rb
+++ b/app/models/challenge_data_set.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: challenge_data_sets
+#
+#  id           :bigint           not null, primary key
+#  challenge_id :integer
+#  data_set_id  :integer
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
 class ChallengeDataSet < ApplicationRecord
   belongs_to :challenge
   belongs_to :data_set

--- a/app/models/challenge_data_set.rb
+++ b/app/models/challenge_data_set.rb
@@ -3,10 +3,15 @@
 # Table name: challenge_data_sets
 #
 #  id           :bigint           not null, primary key
-#  challenge_id :integer
-#  data_set_id  :integer
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
+#  challenge_id :integer
+#  data_set_id  :integer
+#
+# Indexes
+#
+#  index_challenge_data_sets_on_challenge_id  (challenge_id)
+#  index_challenge_data_sets_on_data_set_id   (data_set_id)
 #
 class ChallengeDataSet < ApplicationRecord
   belongs_to :challenge

--- a/app/models/challenge_sponsorship.rb
+++ b/app/models/challenge_sponsorship.rb
@@ -3,11 +3,16 @@
 # Table name: challenge_sponsorships
 #
 #  id           :bigint           not null, primary key
-#  challenge_id :integer
-#  sponsor_id   :integer
+#  approved     :boolean          default(FALSE)
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
-#  approved     :boolean          default(FALSE)
+#  challenge_id :integer
+#  sponsor_id   :integer
+#
+# Indexes
+#
+#  index_challenge_sponsorships_on_challenge_id  (challenge_id)
+#  index_challenge_sponsorships_on_sponsor_id    (sponsor_id)
 #
 class ChallengeSponsorship < ApplicationRecord
   belongs_to :sponsor

--- a/app/models/challenge_sponsorship.rb
+++ b/app/models/challenge_sponsorship.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: challenge_sponsorships
+#
+#  id           :bigint           not null, primary key
+#  challenge_id :integer
+#  sponsor_id   :integer
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  approved     :boolean          default(FALSE)
+#
 class ChallengeSponsorship < ApplicationRecord
   belongs_to :sponsor
   belongs_to :challenge

--- a/app/models/checkpoint.rb
+++ b/app/models/checkpoint.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: checkpoints
+#
+#  id                      :bigint           not null, primary key
+#  competition_id          :integer
+#  end_time                :datetime
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  max_regional_challenges :integer
+#  max_national_challenges :integer
+#  name                    :string
+#
 class Checkpoint < ApplicationRecord
   belongs_to :competition
   has_many :entries, dependent: :destroy

--- a/app/models/checkpoint.rb
+++ b/app/models/checkpoint.rb
@@ -3,13 +3,17 @@
 # Table name: checkpoints
 #
 #  id                      :bigint           not null, primary key
-#  competition_id          :integer
 #  end_time                :datetime
+#  max_national_challenges :integer
+#  max_regional_challenges :integer
+#  name                    :string
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
-#  max_regional_challenges :integer
-#  max_national_challenges :integer
-#  name                    :string
+#  competition_id          :integer
+#
+# Indexes
+#
+#  index_checkpoints_on_competition_id  (competition_id)
 #
 class Checkpoint < ApplicationRecord
   belongs_to :competition

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -3,20 +3,25 @@
 # Table name: competitions
 #
 #  id                      :bigint           not null, primary key
+#  challenge_judging_end   :datetime
+#  challenge_judging_start :datetime
+#  current                 :boolean
+#  end_time                :datetime
+#  hunt_published          :boolean
+#  peoples_choice_end      :datetime
+#  peoples_choice_start    :datetime
+#  start_time              :datetime
+#  team_form_end           :datetime
+#  team_form_start         :datetime
 #  year                    :integer
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
-#  start_time              :datetime
-#  end_time                :datetime
-#  peoples_choice_start    :datetime
-#  peoples_choice_end      :datetime
-#  challenge_judging_start :datetime
-#  challenge_judging_end   :datetime
-#  current                 :boolean
-#  team_form_start         :datetime
-#  team_form_end           :datetime
 #  hunt_badge_id           :integer
-#  hunt_published          :boolean
+#
+# Indexes
+#
+#  index_competitions_on_current  (current)
+#  index_competitions_on_year     (year)
 #
 class Competition < ApplicationRecord
   has_many :assignments, as: :assignable

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -1,3 +1,23 @@
+# == Schema Information
+#
+# Table name: competitions
+#
+#  id                      :bigint           not null, primary key
+#  year                    :integer
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  start_time              :datetime
+#  end_time                :datetime
+#  peoples_choice_start    :datetime
+#  peoples_choice_end      :datetime
+#  challenge_judging_start :datetime
+#  challenge_judging_end   :datetime
+#  current                 :boolean
+#  team_form_start         :datetime
+#  team_form_end           :datetime
+#  hunt_badge_id           :integer
+#  hunt_published          :boolean
+#
 class Competition < ApplicationRecord
   has_many :assignments, as: :assignable
   has_many :holders, dependent: :destroy

--- a/app/models/criterion.rb
+++ b/app/models/criterion.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: criteria
+#
+#  id             :bigint           not null, primary key
+#  competition_id :integer
+#  description    :text
+#  category       :string
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  name           :string
+#
 class Criterion < ApplicationRecord
   belongs_to :competition
   has_many :scores

--- a/app/models/criterion.rb
+++ b/app/models/criterion.rb
@@ -3,12 +3,16 @@
 # Table name: criteria
 #
 #  id             :bigint           not null, primary key
-#  competition_id :integer
-#  description    :text
 #  category       :string
+#  description    :text
+#  name           :string
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
-#  name           :string
+#  competition_id :integer
+#
+# Indexes
+#
+#  index_criteria_on_competition_id  (competition_id)
 #
 class Criterion < ApplicationRecord
   belongs_to :competition

--- a/app/models/data_set.rb
+++ b/app/models/data_set.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: data_sets
+#
+#  id          :bigint           not null, primary key
+#  region_id   :integer
+#  name        :string
+#  url         :string
+#  description :text
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 class DataSet < ApplicationRecord
   belongs_to :region
   has_one :competition, through: :region

--- a/app/models/data_set.rb
+++ b/app/models/data_set.rb
@@ -3,12 +3,16 @@
 # Table name: data_sets
 #
 #  id          :bigint           not null, primary key
-#  region_id   :integer
+#  description :text
 #  name        :string
 #  url         :string
-#  description :text
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#  region_id   :integer
+#
+# Indexes
+#
+#  index_data_sets_on_region_id  (region_id)
 #
 class DataSet < ApplicationRecord
   belongs_to :region

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: datasets
+#
+#  id          :bigint           not null, primary key
+#  name        :string
+#  url         :string
+#  description :text
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 class Dataset < ApplicationRecord
   scope :search, lambda { |term|
     where 'datasets.name ILIKE ? OR url ILIKE ? OR description ILIKE ?',

--- a/app/models/employment_status.rb
+++ b/app/models/employment_status.rb
@@ -1,3 +1,22 @@
+# == Schema Information
+#
+# Table name: employment_statuses
+#
+#  id                       :bigint           not null, primary key
+#  profile_id               :integer
+#  full_time_employed       :boolean
+#  part_time_casual         :boolean
+#  self_employed            :boolean
+#  full_time_student        :boolean
+#  part_time_student        :boolean
+#  not_employed_looking     :boolean
+#  not_employed_not_looking :boolean
+#  retired                  :boolean
+#  not_able_to_work         :boolean
+#  prefer_not_to_say        :boolean
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#
 class EmploymentStatus < ApplicationRecord
   belongs_to :profile
 

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -1,3 +1,17 @@
+# == Schema Information
+#
+# Table name: entries
+#
+#  id            :bigint           not null, primary key
+#  team_id       :integer
+#  challenge_id  :integer
+#  checkpoint_id :integer
+#  justification :text
+#  eligible      :boolean
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  award         :string
+#
 class Entry < ApplicationRecord
   belongs_to :checkpoint
   belongs_to :challenge

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -3,14 +3,22 @@
 # Table name: entries
 #
 #  id            :bigint           not null, primary key
-#  team_id       :integer
-#  challenge_id  :integer
-#  checkpoint_id :integer
-#  justification :text
+#  award         :string
 #  eligible      :boolean
+#  justification :text
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
-#  award         :string
+#  challenge_id  :integer
+#  checkpoint_id :integer
+#  team_id       :integer
+#
+# Indexes
+#
+#  index_entries_on_award          (award)
+#  index_entries_on_challenge_id   (challenge_id)
+#  index_entries_on_checkpoint_id  (checkpoint_id)
+#  index_entries_on_eligible       (eligible)
+#  index_entries_on_team_id        (team_id)
 #
 class Entry < ApplicationRecord
   belongs_to :checkpoint

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,3 +1,32 @@
+# == Schema Information
+#
+# Table name: events
+#
+#  id                :bigint           not null, primary key
+#  region_id         :integer
+#  name              :string
+#  registration_type :string
+#  capacity          :integer
+#  email             :string
+#  twitter           :string
+#  address           :text
+#  accessibility     :text
+#  youth_support     :text
+#  parking           :text
+#  public_transport  :text
+#  operation_hours   :text
+#  catering          :text
+#  video_id          :string
+#  start_time        :datetime
+#  end_time          :datetime
+#  published         :boolean          default(FALSE)
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  place_id          :string
+#  identifier        :string
+#  event_type        :string
+#  description       :text
+#
 class Event < ApplicationRecord
   belongs_to :region
   has_one :competition, through: :region

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -3,29 +3,35 @@
 # Table name: events
 #
 #  id                :bigint           not null, primary key
-#  region_id         :integer
-#  name              :string
-#  registration_type :string
-#  capacity          :integer
-#  email             :string
-#  twitter           :string
-#  address           :text
 #  accessibility     :text
-#  youth_support     :text
+#  address           :text
+#  capacity          :integer
+#  catering          :text
+#  description       :text
+#  email             :string
+#  end_time          :datetime
+#  event_type        :string
+#  identifier        :string
+#  name              :string
+#  operation_hours   :text
 #  parking           :text
 #  public_transport  :text
-#  operation_hours   :text
-#  catering          :text
-#  video_id          :string
-#  start_time        :datetime
-#  end_time          :datetime
 #  published         :boolean          default(FALSE)
+#  registration_type :string
+#  start_time        :datetime
+#  twitter           :string
+#  youth_support     :text
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  place_id          :string
-#  identifier        :string
-#  event_type        :string
-#  description       :text
+#  region_id         :integer
+#  video_id          :string
+#
+# Indexes
+#
+#  index_events_on_identifier  (identifier)
+#  index_events_on_published   (published)
+#  index_events_on_region_id   (region_id)
 #
 class Event < ApplicationRecord
   belongs_to :region

--- a/app/models/event_partnership.rb
+++ b/app/models/event_partnership.rb
@@ -3,11 +3,17 @@
 # Table name: event_partnerships
 #
 #  id         :bigint           not null, primary key
-#  event_id   :integer
-#  sponsor_id :integer
 #  approved   :boolean          default(FALSE)
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  event_id   :integer
+#  sponsor_id :integer
+#
+# Indexes
+#
+#  index_event_partnerships_on_approved    (approved)
+#  index_event_partnerships_on_event_id    (event_id)
+#  index_event_partnerships_on_sponsor_id  (sponsor_id)
 #
 class EventPartnership < ApplicationRecord
   belongs_to :event

--- a/app/models/event_partnership.rb
+++ b/app/models/event_partnership.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: event_partnerships
+#
+#  id         :bigint           not null, primary key
+#  event_id   :integer
+#  sponsor_id :integer
+#  approved   :boolean          default(FALSE)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 class EventPartnership < ApplicationRecord
   belongs_to :event
   belongs_to :sponsor

--- a/app/models/favourite.rb
+++ b/app/models/favourite.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: favourites
+#
+#  id            :bigint           not null, primary key
+#  assignment_id :integer
+#  team_id       :integer
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  holder_id     :integer
+#
 class Favourite < ApplicationRecord
   belongs_to :team
   belongs_to :holder

--- a/app/models/favourite.rb
+++ b/app/models/favourite.rb
@@ -3,11 +3,17 @@
 # Table name: favourites
 #
 #  id            :bigint           not null, primary key
-#  assignment_id :integer
-#  team_id       :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
+#  assignment_id :integer
 #  holder_id     :integer
+#  team_id       :integer
+#
+# Indexes
+#
+#  index_favourites_on_assignment_id  (assignment_id)
+#  index_favourites_on_holder_id      (holder_id)
+#  index_favourites_on_team_id        (team_id)
 #
 class Favourite < ApplicationRecord
   belongs_to :team

--- a/app/models/header.rb
+++ b/app/models/header.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: headers
+#
+#  id             :bigint           not null, primary key
+#  assignment_id  :integer
+#  scoreable_type :string
+#  scoreable_id   :bigint
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  included       :boolean          default(TRUE)
+#
 class Header < ApplicationRecord
   belongs_to :scoreable, polymorphic: true
   belongs_to :assignment

--- a/app/models/header.rb
+++ b/app/models/header.rb
@@ -3,12 +3,18 @@
 # Table name: headers
 #
 #  id             :bigint           not null, primary key
-#  assignment_id  :integer
+#  included       :boolean          default(TRUE)
 #  scoreable_type :string
-#  scoreable_id   :bigint
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
-#  included       :boolean          default(TRUE)
+#  assignment_id  :integer
+#  scoreable_id   :bigint
+#
+# Indexes
+#
+#  index_headers_on_assignment_id                    (assignment_id)
+#  index_headers_on_included                         (included)
+#  index_headers_on_scoreable_type_and_scoreable_id  (scoreable_type,scoreable_id)
 #
 class Header < ApplicationRecord
   belongs_to :scoreable, polymorphic: true

--- a/app/models/holder.rb
+++ b/app/models/holder.rb
@@ -3,13 +3,27 @@
 # Table name: holders
 #
 #  id                    :bigint           not null, primary key
-#  user_id               :bigint           not null
-#  competition_id        :bigint           not null
 #  aws_credits_requested :boolean
+#  team_status           :integer
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
-#  team_status           :integer
+#  competition_id        :bigint           not null
 #  profile_id            :bigint
+#  user_id               :bigint           not null
+#
+# Indexes
+#
+#  index_holders_on_aws_credits_requested  (aws_credits_requested)
+#  index_holders_on_competition_id         (competition_id)
+#  index_holders_on_profile_id             (profile_id)
+#  index_holders_on_team_status            (team_status)
+#  index_holders_on_user_id                (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (competition_id => competitions.id)
+#  fk_rails_...  (profile_id => profiles.id)
+#  fk_rails_...  (user_id => users.id)
 #
 class Holder < ApplicationRecord
   belongs_to :user

--- a/app/models/holder.rb
+++ b/app/models/holder.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: holders
+#
+#  id                    :bigint           not null, primary key
+#  user_id               :bigint           not null
+#  competition_id        :bigint           not null
+#  aws_credits_requested :boolean
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  team_status           :integer
+#  profile_id            :bigint
+#
 class Holder < ApplicationRecord
   belongs_to :user
   belongs_to :profile

--- a/app/models/hunt_question.rb
+++ b/app/models/hunt_question.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: hunt_questions
+#
+#  id             :bigint           not null, primary key
+#  competition_id :integer
+#  question       :string
+#  answer         :string
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#
 class HuntQuestion < ApplicationRecord
   belongs_to :competition
 

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -3,26 +3,30 @@
 # Table name: profiles
 #
 #  id                 :bigint           not null, primary key
-#  user_id            :integer
 #  age                :integer
-#  gender             :string
-#  first_peoples      :integer
+#  description        :string
 #  disability         :integer
 #  education          :integer
-#  users              :string
+#  first_peoples      :integer
+#  gender             :string
+#  github             :string
+#  identifier         :string
+#  linkedin           :string
 #  postcode           :string
+#  published          :boolean
+#  slack_access_token :string
+#  team_status        :integer
+#  twitter            :string
+#  users              :string
+#  website            :string
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
-#  identifier         :string
-#  team_status        :integer
-#  website            :string
-#  linkedin           :string
-#  twitter            :string
-#  description        :string
-#  github             :string
-#  published          :boolean
 #  slack_user_id      :string
-#  slack_access_token :string
+#  user_id            :integer
+#
+# Indexes
+#
+#  index_profiles_on_identifier  (identifier)
 #
 class Profile < ApplicationRecord
   belongs_to :user

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,3 +1,29 @@
+# == Schema Information
+#
+# Table name: profiles
+#
+#  id                 :bigint           not null, primary key
+#  user_id            :integer
+#  age                :integer
+#  gender             :string
+#  first_peoples      :integer
+#  disability         :integer
+#  education          :integer
+#  users              :string
+#  postcode           :string
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  identifier         :string
+#  team_status        :integer
+#  website            :string
+#  linkedin           :string
+#  twitter            :string
+#  description        :string
+#  github             :string
+#  published          :boolean
+#  slack_user_id      :string
+#  slack_access_token :string
+#
 class Profile < ApplicationRecord
   belongs_to :user
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,3 +1,21 @@
+# == Schema Information
+#
+# Table name: projects
+#
+#  id              :bigint           not null, primary key
+#  team_id         :integer
+#  team_name       :string
+#  description     :text
+#  data_story      :text
+#  source_code_url :string
+#  video_url       :string
+#  homepage_url    :string
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  user_id         :integer
+#  project_name    :string
+#  identifier      :string
+#
 class Project < ApplicationRecord
   belongs_to :team
   belongs_to :user

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -3,18 +3,24 @@
 # Table name: projects
 #
 #  id              :bigint           not null, primary key
-#  team_id         :integer
-#  team_name       :string
-#  description     :text
 #  data_story      :text
-#  source_code_url :string
-#  video_url       :string
+#  description     :text
 #  homepage_url    :string
+#  identifier      :string
+#  project_name    :string
+#  source_code_url :string
+#  team_name       :string
+#  video_url       :string
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
+#  team_id         :integer
 #  user_id         :integer
-#  project_name    :string
-#  identifier      :string
+#
+# Indexes
+#
+#  index_projects_on_identifier  (identifier)
+#  index_projects_on_team_id     (team_id)
+#  index_projects_on_user_id     (user_id)
 #
 class Project < ApplicationRecord
   belongs_to :team

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -3,15 +3,21 @@
 # Table name: regions
 #
 #  id             :bigint           not null, primary key
-#  name           :string
-#  time_zone      :string
-#  parent_id      :integer
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
 #  award_release  :datetime
-#  competition_id :integer
 #  category       :string
 #  identifier     :string
+#  name           :string
+#  time_zone      :string
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  competition_id :integer
+#  parent_id      :integer
+#
+# Indexes
+#
+#  index_regions_on_competition_id  (competition_id)
+#  index_regions_on_identifier      (identifier)
+#  index_regions_on_parent_id       (parent_id)
 #
 class Region < ApplicationRecord
   # Region Categories

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: regions
+#
+#  id             :bigint           not null, primary key
+#  name           :string
+#  time_zone      :string
+#  parent_id      :integer
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  award_release  :datetime
+#  competition_id :integer
+#  category       :string
+#  identifier     :string
+#
 class Region < ApplicationRecord
   # Region Categories
   INTERNATIONAL = 'International'.freeze

--- a/app/models/region_limit.rb
+++ b/app/models/region_limit.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: region_limits
+#
+#  id                      :bigint           not null, primary key
+#  region_id               :integer
+#  checkpoint_id           :integer
+#  max_regional_challenges :integer
+#  max_national_challenges :integer
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#
 class RegionLimit < ApplicationRecord
   belongs_to :region
   belongs_to :checkpoint

--- a/app/models/region_limit.rb
+++ b/app/models/region_limit.rb
@@ -3,12 +3,17 @@
 # Table name: region_limits
 #
 #  id                      :bigint           not null, primary key
-#  region_id               :integer
-#  checkpoint_id           :integer
-#  max_regional_challenges :integer
 #  max_national_challenges :integer
+#  max_regional_challenges :integer
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
+#  checkpoint_id           :integer
+#  region_id               :integer
+#
+# Indexes
+#
+#  index_region_limits_on_checkpoint_id  (checkpoint_id)
+#  index_region_limits_on_region_id      (region_id)
 #
 class RegionLimit < ApplicationRecord
   belongs_to :region

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -3,13 +3,20 @@
 # Table name: registrations
 #
 #  id            :bigint           not null, primary key
-#  assignment_id :integer
-#  time_notified :datetime
 #  status        :string
+#  time_notified :datetime
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
+#  assignment_id :integer
 #  event_id      :integer
 #  holder_id     :integer
+#
+# Indexes
+#
+#  index_registrations_on_assignment_id  (assignment_id)
+#  index_registrations_on_event_id       (event_id)
+#  index_registrations_on_holder_id      (holder_id)
+#  index_registrations_on_status         (status)
 #
 class Registration < ApplicationRecord
   belongs_to :holder

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: registrations
+#
+#  id            :bigint           not null, primary key
+#  assignment_id :integer
+#  time_notified :datetime
+#  status        :string
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  event_id      :integer
+#  holder_id     :integer
+#
 class Registration < ApplicationRecord
   belongs_to :holder
   belongs_to :assignment

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: resources
+#
+#  id                 :bigint           not null, primary key
+#  competition_id     :integer
+#  category           :integer
+#  position           :integer
+#  url                :string
+#  name               :string
+#  short_url          :string
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  show_on_front_page :boolean
+#
 class Resource < ApplicationRecord
   include Position
 

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -3,15 +3,19 @@
 # Table name: resources
 #
 #  id                 :bigint           not null, primary key
-#  competition_id     :integer
 #  category           :integer
-#  position           :integer
-#  url                :string
 #  name               :string
+#  position           :integer
 #  short_url          :string
+#  show_on_front_page :boolean
+#  url                :string
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
-#  show_on_front_page :boolean
+#  competition_id     :integer
+#
+# Indexes
+#
+#  index_resources_on_show_on_front_page  (show_on_front_page)
 #
 class Resource < ApplicationRecord
   include Position

--- a/app/models/score.rb
+++ b/app/models/score.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: scores
+#
+#  id           :bigint           not null, primary key
+#  header_id    :integer
+#  criterion_id :integer
+#  entry        :integer
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
 class Score < ApplicationRecord
   belongs_to :header
   belongs_to :criterion

--- a/app/models/score.rb
+++ b/app/models/score.rb
@@ -3,11 +3,16 @@
 # Table name: scores
 #
 #  id           :bigint           not null, primary key
-#  header_id    :integer
-#  criterion_id :integer
 #  entry        :integer
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
+#  criterion_id :integer
+#  header_id    :integer
+#
+# Indexes
+#
+#  index_scores_on_criterion_id  (criterion_id)
+#  index_scores_on_header_id     (header_id)
 #
 class Score < ApplicationRecord
   belongs_to :header

--- a/app/models/sponsor.rb
+++ b/app/models/sponsor.rb
@@ -3,12 +3,16 @@
 # Table name: sponsors
 #
 #  id             :bigint           not null, primary key
-#  name           :string
 #  description    :text
+#  name           :string
 #  url            :string
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #  competition_id :integer
+#
+# Indexes
+#
+#  index_sponsors_on_competition_id  (competition_id)
 #
 class Sponsor < ApplicationRecord
   belongs_to :competition

--- a/app/models/sponsor.rb
+++ b/app/models/sponsor.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: sponsors
+#
+#  id             :bigint           not null, primary key
+#  name           :string
+#  description    :text
+#  url            :string
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  competition_id :integer
+#
 class Sponsor < ApplicationRecord
   belongs_to :competition
 

--- a/app/models/sponsorship.rb
+++ b/app/models/sponsorship.rb
@@ -3,13 +3,19 @@
 # Table name: sponsorships
 #
 #  id                  :bigint           not null, primary key
-#  sponsor_id          :integer
-#  sponsorship_type_id :integer
+#  approved            :boolean          default(FALSE)
 #  sponsorable_type    :string
-#  sponsorable_id      :integer
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
-#  approved            :boolean          default(FALSE)
+#  sponsor_id          :integer
+#  sponsorable_id      :integer
+#  sponsorship_type_id :integer
+#
+# Indexes
+#
+#  index_sponsorships_on_approved                             (approved)
+#  index_sponsorships_on_sponsor_id                           (sponsor_id)
+#  index_sponsorships_on_sponsorable_type_and_sponsorable_id  (sponsorable_type,sponsorable_id)
 #
 class Sponsorship < ApplicationRecord
   belongs_to :sponsor

--- a/app/models/sponsorship.rb
+++ b/app/models/sponsorship.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: sponsorships
+#
+#  id                  :bigint           not null, primary key
+#  sponsor_id          :integer
+#  sponsorship_type_id :integer
+#  sponsorable_type    :string
+#  sponsorable_id      :integer
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  approved            :boolean          default(FALSE)
+#
 class Sponsorship < ApplicationRecord
   belongs_to :sponsor
   belongs_to :sponsorable, polymorphic: true

--- a/app/models/sponsorship_type.rb
+++ b/app/models/sponsorship_type.rb
@@ -3,11 +3,16 @@
 # Table name: sponsorship_types
 #
 #  id             :bigint           not null, primary key
-#  competition_id :integer
 #  name           :string
 #  position       :integer
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
+#  competition_id :integer
+#
+# Indexes
+#
+#  index_sponsorship_types_on_competition_id  (competition_id)
+#  index_sponsorship_types_on_position        (position)
 #
 class SponsorshipType < ApplicationRecord
   include Position

--- a/app/models/sponsorship_type.rb
+++ b/app/models/sponsorship_type.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: sponsorship_types
+#
+#  id             :bigint           not null, primary key
+#  competition_id :integer
+#  name           :string
+#  position       :integer
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#
 class SponsorshipType < ApplicationRecord
   include Position
 

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,3 +1,17 @@
+# == Schema Information
+#
+# Table name: teams
+#
+#  id                 :bigint           not null, primary key
+#  event_id           :integer
+#  project_id         :integer
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  published          :boolean          default(TRUE)
+#  youth_team         :boolean          default(FALSE)
+#  slack_channel_id   :string
+#  slack_channel_name :string
+#
 class Team < ApplicationRecord
   belongs_to :event
   belongs_to :current_project, class_name: 'Project', foreign_key: 'project_id', optional: true

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -3,14 +3,20 @@
 # Table name: teams
 #
 #  id                 :bigint           not null, primary key
-#  event_id           :integer
-#  project_id         :integer
+#  published          :boolean          default(TRUE)
+#  slack_channel_name :string
+#  youth_team         :boolean          default(FALSE)
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
-#  published          :boolean          default(TRUE)
-#  youth_team         :boolean          default(FALSE)
+#  event_id           :integer
+#  project_id         :integer
 #  slack_channel_id   :string
-#  slack_channel_name :string
+#
+# Indexes
+#
+#  index_teams_on_event_id    (event_id)
+#  index_teams_on_project_id  (project_id)
+#  index_teams_on_published   (published)
 #
 class Team < ApplicationRecord
   belongs_to :event

--- a/app/models/team_data_set.rb
+++ b/app/models/team_data_set.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: team_data_sets
+#
+#  id                 :bigint           not null, primary key
+#  team_id            :integer
+#  name               :string
+#  description        :text
+#  description_of_use :text
+#  url                :string
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#
 class TeamDataSet < ApplicationRecord
   belongs_to :team
 

--- a/app/models/team_data_set.rb
+++ b/app/models/team_data_set.rb
@@ -3,13 +3,17 @@
 # Table name: team_data_sets
 #
 #  id                 :bigint           not null, primary key
-#  team_id            :integer
-#  name               :string
 #  description        :text
 #  description_of_use :text
+#  name               :string
 #  url                :string
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
+#  team_id            :integer
+#
+# Indexes
+#
+#  index_team_data_sets_on_team_id  (team_id)
 #
 class TeamDataSet < ApplicationRecord
   belongs_to :team

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,55 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                              :bigint           not null, primary key
+#  email                           :string           default(""), not null
+#  encrypted_password              :string           default(""), not null
+#  full_name                       :string           default(""), not null
+#  preferred_name                  :string
+#  preferred_img                   :string
+#  google_img                      :string
+#  dietary_requirements            :text
+#  tshirt_size                     :string
+#  mailing_list                    :boolean          default(FALSE)
+#  challenge_sponsor_contact_place :boolean          default(FALSE)
+#  challenge_sponsor_contact_enter :boolean          default(FALSE)
+#  my_project_sponsor_contact      :boolean          default(FALSE)
+#  me_govhack_contact              :boolean          default(FALSE)
+#  reset_password_token            :string
+#  reset_password_sent_at          :datetime
+#  remember_created_at             :datetime
+#  sign_in_count                   :integer          default(0), not null
+#  current_sign_in_at              :datetime
+#  last_sign_in_at                 :datetime
+#  current_sign_in_ip              :inet
+#  last_sign_in_ip                 :inet
+#  confirmation_token              :string
+#  confirmed_at                    :datetime
+#  confirmation_sent_at            :datetime
+#  unconfirmed_email               :string
+#  failed_attempts                 :integer          default(0), not null
+#  unlock_token                    :string
+#  locked_at                       :datetime
+#  created_at                      :datetime         not null
+#  updated_at                      :datetime         not null
+#  organisation_name               :string
+#  phone_number                    :string
+#  how_did_you_hear                :text
+#  accepted_terms_and_conditions   :boolean
+#  registration_type               :string
+#  parent_guardian                 :string
+#  request_not_photographed        :boolean          default(FALSE)
+#  data_cruncher                   :boolean          default(FALSE)
+#  coder                           :boolean          default(FALSE)
+#  creative                        :boolean          default(FALSE)
+#  facilitator                     :boolean          default(FALSE)
+#  slack                           :string
+#  accepted_code_of_conduct        :datetime
+#  under_18                        :boolean
+#  region                          :integer
+#  acting_on_behalf_of_id          :integer
+#
 class User < ApplicationRecord
   # Devise options
   devise :database_authenticatable, :registerable, :recoverable, :rememberable,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,52 +3,61 @@
 # Table name: users
 #
 #  id                              :bigint           not null, primary key
-#  email                           :string           default(""), not null
-#  encrypted_password              :string           default(""), not null
-#  full_name                       :string           default(""), not null
-#  preferred_name                  :string
-#  preferred_img                   :string
-#  google_img                      :string
-#  dietary_requirements            :text
-#  tshirt_size                     :string
-#  mailing_list                    :boolean          default(FALSE)
-#  challenge_sponsor_contact_place :boolean          default(FALSE)
+#  accepted_code_of_conduct        :datetime
+#  accepted_terms_and_conditions   :boolean
 #  challenge_sponsor_contact_enter :boolean          default(FALSE)
-#  my_project_sponsor_contact      :boolean          default(FALSE)
-#  me_govhack_contact              :boolean          default(FALSE)
-#  reset_password_token            :string
-#  reset_password_sent_at          :datetime
-#  remember_created_at             :datetime
-#  sign_in_count                   :integer          default(0), not null
-#  current_sign_in_at              :datetime
-#  last_sign_in_at                 :datetime
-#  current_sign_in_ip              :inet
-#  last_sign_in_ip                 :inet
+#  challenge_sponsor_contact_place :boolean          default(FALSE)
+#  coder                           :boolean          default(FALSE)
+#  confirmation_sent_at            :datetime
 #  confirmation_token              :string
 #  confirmed_at                    :datetime
-#  confirmation_sent_at            :datetime
-#  unconfirmed_email               :string
+#  creative                        :boolean          default(FALSE)
+#  current_sign_in_at              :datetime
+#  current_sign_in_ip              :inet
+#  data_cruncher                   :boolean          default(FALSE)
+#  dietary_requirements            :text
+#  email                           :string           default(""), not null
+#  encrypted_password              :string           default(""), not null
+#  facilitator                     :boolean          default(FALSE)
 #  failed_attempts                 :integer          default(0), not null
-#  unlock_token                    :string
+#  full_name                       :string           default(""), not null
+#  google_img                      :string
+#  how_did_you_hear                :text
+#  last_sign_in_at                 :datetime
+#  last_sign_in_ip                 :inet
 #  locked_at                       :datetime
+#  mailing_list                    :boolean          default(FALSE)
+#  me_govhack_contact              :boolean          default(FALSE)
+#  my_project_sponsor_contact      :boolean          default(FALSE)
+#  organisation_name               :string
+#  parent_guardian                 :string
+#  phone_number                    :string
+#  preferred_img                   :string
+#  preferred_name                  :string
+#  region                          :integer
+#  registration_type               :string
+#  remember_created_at             :datetime
+#  request_not_photographed        :boolean          default(FALSE)
+#  reset_password_sent_at          :datetime
+#  reset_password_token            :string
+#  sign_in_count                   :integer          default(0), not null
+#  slack                           :string
+#  tshirt_size                     :string
+#  unconfirmed_email               :string
+#  under_18                        :boolean
+#  unlock_token                    :string
 #  created_at                      :datetime         not null
 #  updated_at                      :datetime         not null
-#  organisation_name               :string
-#  phone_number                    :string
-#  how_did_you_hear                :text
-#  accepted_terms_and_conditions   :boolean
-#  registration_type               :string
-#  parent_guardian                 :string
-#  request_not_photographed        :boolean          default(FALSE)
-#  data_cruncher                   :boolean          default(FALSE)
-#  coder                           :boolean          default(FALSE)
-#  creative                        :boolean          default(FALSE)
-#  facilitator                     :boolean          default(FALSE)
-#  slack                           :string
-#  accepted_code_of_conduct        :datetime
-#  under_18                        :boolean
-#  region                          :integer
 #  acting_on_behalf_of_id          :integer
+#
+# Indexes
+#
+#  index_users_on_confirmation_token    (confirmation_token) UNIQUE
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_region                (region)
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#  index_users_on_under_18              (under_18)
+#  index_users_on_unlock_token          (unlock_token) UNIQUE
 #
 class User < ApplicationRecord
   # Devise options

--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -4,11 +4,22 @@
 #
 #  id             :bigint           not null, primary key
 #  visitable_type :string           not null
-#  visitable_id   :bigint           not null
-#  user_id        :bigint
-#  competition_id :bigint           not null
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
+#  competition_id :bigint           not null
+#  user_id        :bigint
+#  visitable_id   :bigint           not null
+#
+# Indexes
+#
+#  index_visits_on_competition_id  (competition_id)
+#  index_visits_on_user_id         (user_id)
+#  index_visits_on_visitable       (visitable_type,visitable_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (competition_id => competitions.id)
+#  fk_rails_...  (user_id => users.id)
 #
 class Visit < ApplicationRecord
   belongs_to :visitable, polymorphic: true

--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: visits
+#
+#  id             :bigint           not null, primary key
+#  visitable_type :string           not null
+#  visitable_id   :bigint           not null
+#  user_id        :bigint
+#  competition_id :bigint           not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#
 class Visit < ApplicationRecord
   belongs_to :visitable, polymorphic: true
   belongs_to :user, optional: true

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -1,0 +1,59 @@
+# NOTE: only doing this in development as some production environments (Heroku)
+# NOTE: are sensitive to local FS writes, and besides -- it's just not proper
+# NOTE: to have a dev-mode tool do its thing in production.
+if Rails.env.development?
+  require 'annotate'
+  task :set_annotation_options do
+    # You can override any of these by setting an environment variable of the
+    # same name.
+    Annotate.set_defaults(
+      'active_admin'                => 'false',
+      'additional_file_patterns'    => [],
+      'routes'                      => 'false',
+      'models'                      => 'true',
+      'position_in_routes'          => 'before',
+      'position_in_class'           => 'before',
+      'position_in_test'            => 'before',
+      'position_in_fixture'         => 'before',
+      'position_in_factory'         => 'before',
+      'position_in_serializer'      => 'before',
+      'show_foreign_keys'           => 'true',
+      'show_complete_foreign_keys'  => 'false',
+      'show_indexes'                => 'true',
+      'simple_indexes'              => 'false',
+      'model_dir'                   => 'app/models',
+      'root_dir'                    => '',
+      'include_version'             => 'false',
+      'require'                     => '',
+      'exclude_tests'               => 'false',
+      'exclude_fixtures'            => 'false',
+      'exclude_factories'           => 'false',
+      'exclude_serializers'         => 'false',
+      'exclude_scaffolds'           => 'true',
+      'exclude_controllers'         => 'true',
+      'exclude_helpers'             => 'true',
+      'exclude_sti_subclasses'      => 'false',
+      'ignore_model_sub_dir'        => 'false',
+      'ignore_columns'              => nil,
+      'ignore_routes'               => nil,
+      'ignore_unknown_models'       => 'false',
+      'hide_limit_column_types'     => 'integer,bigint,boolean',
+      'hide_default_column_types'   => 'json,jsonb,hstore',
+      'skip_on_db_migrate'          => 'false',
+      'format_bare'                 => 'true',
+      'format_rdoc'                 => 'false',
+      'format_yard'                 => 'false',
+      'format_markdown'             => 'false',
+      'sort'                        => 'false',
+      'force'                       => 'false',
+      'frozen'                      => 'false',
+      'classified_sort'             => 'true',
+      'trace'                       => 'false',
+      'wrapper_open'                => nil,
+      'wrapper_close'               => nil,
+      'with_comment'                => 'true'
+    )
+  end
+
+  Annotate.load_tasks
+end

--- a/test/fixtures/assignments.yml
+++ b/test/fixtures/assignments.yml
@@ -1,4 +1,17 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# == Schema Information
+#
+# Table name: assignments
+#
+#  id              :bigint           not null, primary key
+#  user_id         :integer
+#  assignable_type :string
+#  assignable_id   :integer
+#  title           :string
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  competition_id  :integer
+#  holder_id       :integer
+#
 
 # This model initially had no columns defined. If you add columns to the
 # model remove the '{}' from the fixture names and add the columns immediately

--- a/test/fixtures/assignments.yml
+++ b/test/fixtures/assignments.yml
@@ -3,14 +3,22 @@
 # Table name: assignments
 #
 #  id              :bigint           not null, primary key
-#  user_id         :integer
 #  assignable_type :string
-#  assignable_id   :integer
 #  title           :string
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
+#  assignable_id   :integer
 #  competition_id  :integer
 #  holder_id       :integer
+#  user_id         :integer
+#
+# Indexes
+#
+#  index_assignments_on_assignable_type_and_assignable_id  (assignable_type,assignable_id)
+#  index_assignments_on_competition_id                     (competition_id)
+#  index_assignments_on_holder_id                          (holder_id)
+#  index_assignments_on_title                              (title)
+#  index_assignments_on_user_id                            (user_id)
 #
 
 # This model initially had no columns defined. If you add columns to the

--- a/test/fixtures/badges.yml
+++ b/test/fixtures/badges.yml
@@ -1,4 +1,15 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# == Schema Information
+#
+# Table name: badges
+#
+#  id             :bigint           not null, primary key
+#  competition_id :integer
+#  name           :string
+#  identifier     :string
+#  capacity       :integer
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#
 
 one:
   competition: one

--- a/test/fixtures/badges.yml
+++ b/test/fixtures/badges.yml
@@ -3,12 +3,16 @@
 # Table name: badges
 #
 #  id             :bigint           not null, primary key
-#  competition_id :integer
-#  name           :string
-#  identifier     :string
 #  capacity       :integer
+#  identifier     :string
+#  name           :string
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
+#  competition_id :integer
+#
+# Indexes
+#
+#  index_badges_on_identifier  (identifier)
 #
 
 one:

--- a/test/fixtures/challenge_data_sets.yml
+++ b/test/fixtures/challenge_data_sets.yml
@@ -1,4 +1,13 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# == Schema Information
+#
+# Table name: challenge_data_sets
+#
+#  id           :bigint           not null, primary key
+#  challenge_id :integer
+#  data_set_id  :integer
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
 
 one:
   challenge: one

--- a/test/fixtures/challenge_data_sets.yml
+++ b/test/fixtures/challenge_data_sets.yml
@@ -3,10 +3,15 @@
 # Table name: challenge_data_sets
 #
 #  id           :bigint           not null, primary key
-#  challenge_id :integer
-#  data_set_id  :integer
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
+#  challenge_id :integer
+#  data_set_id  :integer
+#
+# Indexes
+#
+#  index_challenge_data_sets_on_challenge_id  (challenge_id)
+#  index_challenge_data_sets_on_data_set_id   (data_set_id)
 #
 
 one:

--- a/test/fixtures/challenge_sponsorships.yml
+++ b/test/fixtures/challenge_sponsorships.yml
@@ -1,4 +1,14 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# == Schema Information
+#
+# Table name: challenge_sponsorships
+#
+#  id           :bigint           not null, primary key
+#  challenge_id :integer
+#  sponsor_id   :integer
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  approved     :boolean          default(FALSE)
+#
 
 one:
   challenge: one

--- a/test/fixtures/challenge_sponsorships.yml
+++ b/test/fixtures/challenge_sponsorships.yml
@@ -3,11 +3,16 @@
 # Table name: challenge_sponsorships
 #
 #  id           :bigint           not null, primary key
-#  challenge_id :integer
-#  sponsor_id   :integer
+#  approved     :boolean          default(FALSE)
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
-#  approved     :boolean          default(FALSE)
+#  challenge_id :integer
+#  sponsor_id   :integer
+#
+# Indexes
+#
+#  index_challenge_sponsorships_on_challenge_id  (challenge_id)
+#  index_challenge_sponsorships_on_sponsor_id    (sponsor_id)
 #
 
 one:

--- a/test/fixtures/challenges.yml
+++ b/test/fixtures/challenges.yml
@@ -3,17 +3,24 @@
 # Table name: challenges
 #
 #  id          :bigint           not null, primary key
-#  region_id   :integer
-#  name        :string
-#  short_desc  :text
-#  long_desc   :text
-#  eligibility :text
-#  video_url   :string
 #  approved    :boolean          default(FALSE)
+#  eligibility :text
+#  identifier  :string
+#  long_desc   :text
+#  name        :string
+#  nation_wide :boolean
+#  short_desc  :text
+#  video_url   :string
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
-#  identifier  :string
-#  nation_wide :boolean
+#  region_id   :integer
+#
+# Indexes
+#
+#  index_challenges_on_approved     (approved)
+#  index_challenges_on_identifier   (identifier)
+#  index_challenges_on_nation_wide  (nation_wide)
+#  index_challenges_on_region_id    (region_id)
 #
 
 one:

--- a/test/fixtures/challenges.yml
+++ b/test/fixtures/challenges.yml
@@ -1,4 +1,20 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# == Schema Information
+#
+# Table name: challenges
+#
+#  id          :bigint           not null, primary key
+#  region_id   :integer
+#  name        :string
+#  short_desc  :text
+#  long_desc   :text
+#  eligibility :text
+#  video_url   :string
+#  approved    :boolean          default(FALSE)
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  identifier  :string
+#  nation_wide :boolean
+#
 
 one:
   region: national

--- a/test/fixtures/checkpoints.yml
+++ b/test/fixtures/checkpoints.yml
@@ -3,13 +3,17 @@
 # Table name: checkpoints
 #
 #  id                      :bigint           not null, primary key
-#  competition_id          :integer
 #  end_time                :datetime
+#  max_national_challenges :integer
+#  max_regional_challenges :integer
+#  name                    :string
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
-#  max_regional_challenges :integer
-#  max_national_challenges :integer
-#  name                    :string
+#  competition_id          :integer
+#
+# Indexes
+#
+#  index_checkpoints_on_competition_id  (competition_id)
 #
 
 one:

--- a/test/fixtures/checkpoints.yml
+++ b/test/fixtures/checkpoints.yml
@@ -1,4 +1,16 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# == Schema Information
+#
+# Table name: checkpoints
+#
+#  id                      :bigint           not null, primary key
+#  competition_id          :integer
+#  end_time                :datetime
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  max_regional_challenges :integer
+#  max_national_challenges :integer
+#  name                    :string
+#
 
 one:
   competition: one

--- a/test/fixtures/competitions.yml
+++ b/test/fixtures/competitions.yml
@@ -3,20 +3,25 @@
 # Table name: competitions
 #
 #  id                      :bigint           not null, primary key
+#  challenge_judging_end   :datetime
+#  challenge_judging_start :datetime
+#  current                 :boolean
+#  end_time                :datetime
+#  hunt_published          :boolean
+#  peoples_choice_end      :datetime
+#  peoples_choice_start    :datetime
+#  start_time              :datetime
+#  team_form_end           :datetime
+#  team_form_start         :datetime
 #  year                    :integer
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
-#  start_time              :datetime
-#  end_time                :datetime
-#  peoples_choice_start    :datetime
-#  peoples_choice_end      :datetime
-#  challenge_judging_start :datetime
-#  challenge_judging_end   :datetime
-#  current                 :boolean
-#  team_form_start         :datetime
-#  team_form_end           :datetime
 #  hunt_badge_id           :integer
-#  hunt_published          :boolean
+#
+# Indexes
+#
+#  index_competitions_on_current  (current)
+#  index_competitions_on_year     (year)
 #
 
 # This model initially had no columns defined. If you add columns to the

--- a/test/fixtures/competitions.yml
+++ b/test/fixtures/competitions.yml
@@ -1,4 +1,23 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# == Schema Information
+#
+# Table name: competitions
+#
+#  id                      :bigint           not null, primary key
+#  year                    :integer
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  start_time              :datetime
+#  end_time                :datetime
+#  peoples_choice_start    :datetime
+#  peoples_choice_end      :datetime
+#  challenge_judging_start :datetime
+#  challenge_judging_end   :datetime
+#  current                 :boolean
+#  team_form_start         :datetime
+#  team_form_end           :datetime
+#  hunt_badge_id           :integer
+#  hunt_published          :boolean
+#
 
 # This model initially had no columns defined. If you add columns to the
 # model remove the '{}' from the fixture names and add the columns immediately

--- a/test/fixtures/criteria.yml
+++ b/test/fixtures/criteria.yml
@@ -3,12 +3,16 @@
 # Table name: criteria
 #
 #  id             :bigint           not null, primary key
-#  competition_id :integer
-#  description    :text
 #  category       :string
+#  description    :text
+#  name           :string
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
-#  name           :string
+#  competition_id :integer
+#
+# Indexes
+#
+#  index_criteria_on_competition_id  (competition_id)
 #
 
 one:

--- a/test/fixtures/criteria.yml
+++ b/test/fixtures/criteria.yml
@@ -1,4 +1,15 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# == Schema Information
+#
+# Table name: criteria
+#
+#  id             :bigint           not null, primary key
+#  competition_id :integer
+#  description    :text
+#  category       :string
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  name           :string
+#
 
 one:
   competition: one

--- a/test/fixtures/data_sets.yml
+++ b/test/fixtures/data_sets.yml
@@ -3,12 +3,16 @@
 # Table name: data_sets
 #
 #  id          :bigint           not null, primary key
-#  region_id   :integer
+#  description :text
 #  name        :string
 #  url         :string
-#  description :text
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#  region_id   :integer
+#
+# Indexes
+#
+#  index_data_sets_on_region_id  (region_id)
 #
 
 one:

--- a/test/fixtures/data_sets.yml
+++ b/test/fixtures/data_sets.yml
@@ -1,4 +1,15 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# == Schema Information
+#
+# Table name: data_sets
+#
+#  id          :bigint           not null, primary key
+#  region_id   :integer
+#  name        :string
+#  url         :string
+#  description :text
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 
 one:
   region: national

--- a/test/fixtures/datasets.yml
+++ b/test/fixtures/datasets.yml
@@ -1,4 +1,14 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# == Schema Information
+#
+# Table name: datasets
+#
+#  id          :bigint           not null, primary key
+#  name        :string
+#  url         :string
+#  description :text
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 
 one:
   name: MyString

--- a/test/fixtures/employment_statuses.yml
+++ b/test/fixtures/employment_statuses.yml
@@ -1,4 +1,22 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# == Schema Information
+#
+# Table name: employment_statuses
+#
+#  id                       :bigint           not null, primary key
+#  profile_id               :integer
+#  full_time_employed       :boolean
+#  part_time_casual         :boolean
+#  self_employed            :boolean
+#  full_time_student        :boolean
+#  part_time_student        :boolean
+#  not_employed_looking     :boolean
+#  not_employed_not_looking :boolean
+#  retired                  :boolean
+#  not_able_to_work         :boolean
+#  prefer_not_to_say        :boolean
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#
 
 # This model initially had no columns defined. If you add columns to the
 # model remove the '{}' from the fixture names and add the columns immediately

--- a/test/fixtures/entries.yml
+++ b/test/fixtures/entries.yml
@@ -3,14 +3,22 @@
 # Table name: entries
 #
 #  id            :bigint           not null, primary key
-#  team_id       :integer
-#  challenge_id  :integer
-#  checkpoint_id :integer
-#  justification :text
+#  award         :string
 #  eligible      :boolean
+#  justification :text
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
-#  award         :string
+#  challenge_id  :integer
+#  checkpoint_id :integer
+#  team_id       :integer
+#
+# Indexes
+#
+#  index_entries_on_award          (award)
+#  index_entries_on_challenge_id   (challenge_id)
+#  index_entries_on_checkpoint_id  (checkpoint_id)
+#  index_entries_on_eligible       (eligible)
+#  index_entries_on_team_id        (team_id)
 #
 
 one:

--- a/test/fixtures/entries.yml
+++ b/test/fixtures/entries.yml
@@ -1,4 +1,17 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# == Schema Information
+#
+# Table name: entries
+#
+#  id            :bigint           not null, primary key
+#  team_id       :integer
+#  challenge_id  :integer
+#  checkpoint_id :integer
+#  justification :text
+#  eligible      :boolean
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  award         :string
+#
 
 one:
   team: one

--- a/test/fixtures/event_partnerships.yml
+++ b/test/fixtures/event_partnerships.yml
@@ -1,4 +1,14 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# == Schema Information
+#
+# Table name: event_partnerships
+#
+#  id         :bigint           not null, primary key
+#  event_id   :integer
+#  sponsor_id :integer
+#  approved   :boolean          default(FALSE)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 
 # This model initially had no columns defined. If you add columns to the
 # model remove the '{}' from the fixture names and add the columns immediately

--- a/test/fixtures/event_partnerships.yml
+++ b/test/fixtures/event_partnerships.yml
@@ -3,11 +3,17 @@
 # Table name: event_partnerships
 #
 #  id         :bigint           not null, primary key
-#  event_id   :integer
-#  sponsor_id :integer
 #  approved   :boolean          default(FALSE)
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  event_id   :integer
+#  sponsor_id :integer
+#
+# Indexes
+#
+#  index_event_partnerships_on_approved    (approved)
+#  index_event_partnerships_on_event_id    (event_id)
+#  index_event_partnerships_on_sponsor_id  (sponsor_id)
 #
 
 # This model initially had no columns defined. If you add columns to the

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -1,4 +1,32 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# == Schema Information
+#
+# Table name: events
+#
+#  id                :bigint           not null, primary key
+#  region_id         :integer
+#  name              :string
+#  registration_type :string
+#  capacity          :integer
+#  email             :string
+#  twitter           :string
+#  address           :text
+#  accessibility     :text
+#  youth_support     :text
+#  parking           :text
+#  public_transport  :text
+#  operation_hours   :text
+#  catering          :text
+#  video_id          :string
+#  start_time        :datetime
+#  end_time          :datetime
+#  published         :boolean          default(FALSE)
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  place_id          :string
+#  identifier        :string
+#  event_type        :string
+#  description       :text
+#
 
 # This model initially had no columns defined. If you add columns to the
 # model remove the '{}' from the fixture names and add the columns immediately

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -3,29 +3,35 @@
 # Table name: events
 #
 #  id                :bigint           not null, primary key
-#  region_id         :integer
-#  name              :string
-#  registration_type :string
-#  capacity          :integer
-#  email             :string
-#  twitter           :string
-#  address           :text
 #  accessibility     :text
-#  youth_support     :text
+#  address           :text
+#  capacity          :integer
+#  catering          :text
+#  description       :text
+#  email             :string
+#  end_time          :datetime
+#  event_type        :string
+#  identifier        :string
+#  name              :string
+#  operation_hours   :text
 #  parking           :text
 #  public_transport  :text
-#  operation_hours   :text
-#  catering          :text
-#  video_id          :string
-#  start_time        :datetime
-#  end_time          :datetime
 #  published         :boolean          default(FALSE)
+#  registration_type :string
+#  start_time        :datetime
+#  twitter           :string
+#  youth_support     :text
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  place_id          :string
-#  identifier        :string
-#  event_type        :string
-#  description       :text
+#  region_id         :integer
+#  video_id          :string
+#
+# Indexes
+#
+#  index_events_on_identifier  (identifier)
+#  index_events_on_published   (published)
+#  index_events_on_region_id   (region_id)
 #
 
 # This model initially had no columns defined. If you add columns to the

--- a/test/fixtures/favourites.yml
+++ b/test/fixtures/favourites.yml
@@ -1,4 +1,14 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# == Schema Information
+#
+# Table name: favourites
+#
+#  id            :bigint           not null, primary key
+#  assignment_id :integer
+#  team_id       :integer
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  holder_id     :integer
+#
 
 one:
   assignment: participant

--- a/test/fixtures/favourites.yml
+++ b/test/fixtures/favourites.yml
@@ -3,11 +3,17 @@
 # Table name: favourites
 #
 #  id            :bigint           not null, primary key
-#  assignment_id :integer
-#  team_id       :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
+#  assignment_id :integer
 #  holder_id     :integer
+#  team_id       :integer
+#
+# Indexes
+#
+#  index_favourites_on_assignment_id  (assignment_id)
+#  index_favourites_on_holder_id      (holder_id)
+#  index_favourites_on_team_id        (team_id)
 #
 
 one:

--- a/test/fixtures/headers.yml
+++ b/test/fixtures/headers.yml
@@ -3,12 +3,18 @@
 # Table name: headers
 #
 #  id             :bigint           not null, primary key
-#  assignment_id  :integer
+#  included       :boolean          default(TRUE)
 #  scoreable_type :string
-#  scoreable_id   :bigint
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
-#  included       :boolean          default(TRUE)
+#  assignment_id  :integer
+#  scoreable_id   :bigint
+#
+# Indexes
+#
+#  index_headers_on_assignment_id                    (assignment_id)
+#  index_headers_on_included                         (included)
+#  index_headers_on_scoreable_type_and_scoreable_id  (scoreable_type,scoreable_id)
 #
 
 one:

--- a/test/fixtures/headers.yml
+++ b/test/fixtures/headers.yml
@@ -1,4 +1,15 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# == Schema Information
+#
+# Table name: headers
+#
+#  id             :bigint           not null, primary key
+#  assignment_id  :integer
+#  scoreable_type :string
+#  scoreable_id   :bigint
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  included       :boolean          default(TRUE)
+#
 
 one:
   assignment: judge

--- a/test/fixtures/holders.yml
+++ b/test/fixtures/holders.yml
@@ -3,13 +3,27 @@
 # Table name: holders
 #
 #  id                    :bigint           not null, primary key
-#  user_id               :bigint           not null
-#  competition_id        :bigint           not null
 #  aws_credits_requested :boolean
+#  team_status           :integer
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
-#  team_status           :integer
+#  competition_id        :bigint           not null
 #  profile_id            :bigint
+#  user_id               :bigint           not null
+#
+# Indexes
+#
+#  index_holders_on_aws_credits_requested  (aws_credits_requested)
+#  index_holders_on_competition_id         (competition_id)
+#  index_holders_on_profile_id             (profile_id)
+#  index_holders_on_team_status            (team_status)
+#  index_holders_on_user_id                (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (competition_id => competitions.id)
+#  fk_rails_...  (profile_id => profiles.id)
+#  fk_rails_...  (user_id => users.id)
 #
 
 one:

--- a/test/fixtures/holders.yml
+++ b/test/fixtures/holders.yml
@@ -1,4 +1,16 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# == Schema Information
+#
+# Table name: holders
+#
+#  id                    :bigint           not null, primary key
+#  user_id               :bigint           not null
+#  competition_id        :bigint           not null
+#  aws_credits_requested :boolean
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  team_status           :integer
+#  profile_id            :bigint
+#
 
 one:
   user: one

--- a/test/fixtures/hunt_questions.yml
+++ b/test/fixtures/hunt_questions.yml
@@ -1,4 +1,14 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# == Schema Information
+#
+# Table name: hunt_questions
+#
+#  id             :bigint           not null, primary key
+#  competition_id :integer
+#  question       :string
+#  answer         :string
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#
 
 one:
   competition: one

--- a/test/fixtures/profiles.yml
+++ b/test/fixtures/profiles.yml
@@ -1,4 +1,29 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# == Schema Information
+#
+# Table name: profiles
+#
+#  id                 :bigint           not null, primary key
+#  user_id            :integer
+#  age                :integer
+#  gender             :string
+#  first_peoples      :integer
+#  disability         :integer
+#  education          :integer
+#  users              :string
+#  postcode           :string
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  identifier         :string
+#  team_status        :integer
+#  website            :string
+#  linkedin           :string
+#  twitter            :string
+#  description        :string
+#  github             :string
+#  published          :boolean
+#  slack_user_id      :string
+#  slack_access_token :string
+#
 
 # This model initially had no columns defined. If you add columns to the
 # model remove the '{}' from the fixture names and add the columns immediately

--- a/test/fixtures/profiles.yml
+++ b/test/fixtures/profiles.yml
@@ -3,26 +3,30 @@
 # Table name: profiles
 #
 #  id                 :bigint           not null, primary key
-#  user_id            :integer
 #  age                :integer
-#  gender             :string
-#  first_peoples      :integer
+#  description        :string
 #  disability         :integer
 #  education          :integer
-#  users              :string
+#  first_peoples      :integer
+#  gender             :string
+#  github             :string
+#  identifier         :string
+#  linkedin           :string
 #  postcode           :string
+#  published          :boolean
+#  slack_access_token :string
+#  team_status        :integer
+#  twitter            :string
+#  users              :string
+#  website            :string
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
-#  identifier         :string
-#  team_status        :integer
-#  website            :string
-#  linkedin           :string
-#  twitter            :string
-#  description        :string
-#  github             :string
-#  published          :boolean
 #  slack_user_id      :string
-#  slack_access_token :string
+#  user_id            :integer
+#
+# Indexes
+#
+#  index_profiles_on_identifier  (identifier)
 #
 
 # This model initially had no columns defined. If you add columns to the

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -1,4 +1,21 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# == Schema Information
+#
+# Table name: projects
+#
+#  id              :bigint           not null, primary key
+#  team_id         :integer
+#  team_name       :string
+#  description     :text
+#  data_story      :text
+#  source_code_url :string
+#  video_url       :string
+#  homepage_url    :string
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  user_id         :integer
+#  project_name    :string
+#  identifier      :string
+#
 
 # This model initially had no columns defined. If you add columns to the
 # model remove the '{}' from the fixture names and add the columns immediately

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -3,18 +3,24 @@
 # Table name: projects
 #
 #  id              :bigint           not null, primary key
-#  team_id         :integer
-#  team_name       :string
-#  description     :text
 #  data_story      :text
-#  source_code_url :string
-#  video_url       :string
+#  description     :text
 #  homepage_url    :string
+#  identifier      :string
+#  project_name    :string
+#  source_code_url :string
+#  team_name       :string
+#  video_url       :string
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
+#  team_id         :integer
 #  user_id         :integer
-#  project_name    :string
-#  identifier      :string
+#
+# Indexes
+#
+#  index_projects_on_identifier  (identifier)
+#  index_projects_on_team_id     (team_id)
+#  index_projects_on_user_id     (user_id)
 #
 
 # This model initially had no columns defined. If you add columns to the

--- a/test/fixtures/region_limits.yml
+++ b/test/fixtures/region_limits.yml
@@ -1,4 +1,15 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# == Schema Information
+#
+# Table name: region_limits
+#
+#  id                      :bigint           not null, primary key
+#  region_id               :integer
+#  checkpoint_id           :integer
+#  max_regional_challenges :integer
+#  max_national_challenges :integer
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#
 
 # This model initially had no columns defined. If you add columns to the
 # model remove the '{}' from the fixture names and add the columns immediately

--- a/test/fixtures/region_limits.yml
+++ b/test/fixtures/region_limits.yml
@@ -3,12 +3,17 @@
 # Table name: region_limits
 #
 #  id                      :bigint           not null, primary key
-#  region_id               :integer
-#  checkpoint_id           :integer
-#  max_regional_challenges :integer
 #  max_national_challenges :integer
+#  max_regional_challenges :integer
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
+#  checkpoint_id           :integer
+#  region_id               :integer
+#
+# Indexes
+#
+#  index_region_limits_on_checkpoint_id  (checkpoint_id)
+#  index_region_limits_on_region_id      (region_id)
 #
 
 # This model initially had no columns defined. If you add columns to the

--- a/test/fixtures/regions.yml
+++ b/test/fixtures/regions.yml
@@ -3,15 +3,21 @@
 # Table name: regions
 #
 #  id             :bigint           not null, primary key
-#  name           :string
-#  time_zone      :string
-#  parent_id      :integer
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
 #  award_release  :datetime
-#  competition_id :integer
 #  category       :string
 #  identifier     :string
+#  name           :string
+#  time_zone      :string
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  competition_id :integer
+#  parent_id      :integer
+#
+# Indexes
+#
+#  index_regions_on_competition_id  (competition_id)
+#  index_regions_on_identifier      (identifier)
+#  index_regions_on_parent_id       (parent_id)
 #
 
 national:

--- a/test/fixtures/regions.yml
+++ b/test/fixtures/regions.yml
@@ -1,4 +1,18 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# == Schema Information
+#
+# Table name: regions
+#
+#  id             :bigint           not null, primary key
+#  name           :string
+#  time_zone      :string
+#  parent_id      :integer
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  award_release  :datetime
+#  competition_id :integer
+#  category       :string
+#  identifier     :string
+#
 
 national:
   name: Australia

--- a/test/fixtures/registrations.yml
+++ b/test/fixtures/registrations.yml
@@ -3,13 +3,20 @@
 # Table name: registrations
 #
 #  id            :bigint           not null, primary key
-#  assignment_id :integer
-#  time_notified :datetime
 #  status        :string
+#  time_notified :datetime
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
+#  assignment_id :integer
 #  event_id      :integer
 #  holder_id     :integer
+#
+# Indexes
+#
+#  index_registrations_on_assignment_id  (assignment_id)
+#  index_registrations_on_event_id       (event_id)
+#  index_registrations_on_holder_id      (holder_id)
+#  index_registrations_on_status         (status)
 #
 
 # This model initially had no columns defined. If you add columns to the

--- a/test/fixtures/registrations.yml
+++ b/test/fixtures/registrations.yml
@@ -1,4 +1,16 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# == Schema Information
+#
+# Table name: registrations
+#
+#  id            :bigint           not null, primary key
+#  assignment_id :integer
+#  time_notified :datetime
+#  status        :string
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  event_id      :integer
+#  holder_id     :integer
+#
 
 # This model initially had no columns defined. If you add columns to the
 # model remove the '{}' from the fixture names and add the columns immediately

--- a/test/fixtures/resources.yml
+++ b/test/fixtures/resources.yml
@@ -3,15 +3,19 @@
 # Table name: resources
 #
 #  id                 :bigint           not null, primary key
-#  competition_id     :integer
 #  category           :integer
-#  position           :integer
-#  url                :string
 #  name               :string
+#  position           :integer
 #  short_url          :string
+#  show_on_front_page :boolean
+#  url                :string
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
-#  show_on_front_page :boolean
+#  competition_id     :integer
+#
+# Indexes
+#
+#  index_resources_on_show_on_front_page  (show_on_front_page)
 #
 
 # This model initially had no columns defined. If you add columns to the

--- a/test/fixtures/resources.yml
+++ b/test/fixtures/resources.yml
@@ -1,4 +1,18 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# == Schema Information
+#
+# Table name: resources
+#
+#  id                 :bigint           not null, primary key
+#  competition_id     :integer
+#  category           :integer
+#  position           :integer
+#  url                :string
+#  name               :string
+#  short_url          :string
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  show_on_front_page :boolean
+#
 
 # This model initially had no columns defined. If you add columns to the
 # model remove the '{}' from the fixture names and add the columns immediately

--- a/test/fixtures/scores.yml
+++ b/test/fixtures/scores.yml
@@ -1,4 +1,14 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# == Schema Information
+#
+# Table name: scores
+#
+#  id           :bigint           not null, primary key
+#  header_id    :integer
+#  criterion_id :integer
+#  entry        :integer
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
 
 one:
   header: one

--- a/test/fixtures/scores.yml
+++ b/test/fixtures/scores.yml
@@ -3,11 +3,16 @@
 # Table name: scores
 #
 #  id           :bigint           not null, primary key
-#  header_id    :integer
-#  criterion_id :integer
 #  entry        :integer
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
+#  criterion_id :integer
+#  header_id    :integer
+#
+# Indexes
+#
+#  index_scores_on_criterion_id  (criterion_id)
+#  index_scores_on_header_id     (header_id)
 #
 
 one:

--- a/test/fixtures/sponsors.yml
+++ b/test/fixtures/sponsors.yml
@@ -1,4 +1,15 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# == Schema Information
+#
+# Table name: sponsors
+#
+#  id             :bigint           not null, primary key
+#  name           :string
+#  description    :text
+#  url            :string
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  competition_id :integer
+#
 
 # This model initially had no columns defined. If you add columns to the
 # model remove the '{}' from the fixture names and add the columns immediately

--- a/test/fixtures/sponsors.yml
+++ b/test/fixtures/sponsors.yml
@@ -3,12 +3,16 @@
 # Table name: sponsors
 #
 #  id             :bigint           not null, primary key
-#  name           :string
 #  description    :text
+#  name           :string
 #  url            :string
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #  competition_id :integer
+#
+# Indexes
+#
+#  index_sponsors_on_competition_id  (competition_id)
 #
 
 # This model initially had no columns defined. If you add columns to the

--- a/test/fixtures/sponsorship_types.yml
+++ b/test/fixtures/sponsorship_types.yml
@@ -1,4 +1,14 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# == Schema Information
+#
+# Table name: sponsorship_types
+#
+#  id             :bigint           not null, primary key
+#  competition_id :integer
+#  name           :string
+#  position       :integer
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#
 
 # This model initially had no columns defined. If you add columns to the
 # model remove the '{}' from the fixture names and add the columns immediately

--- a/test/fixtures/sponsorship_types.yml
+++ b/test/fixtures/sponsorship_types.yml
@@ -3,11 +3,16 @@
 # Table name: sponsorship_types
 #
 #  id             :bigint           not null, primary key
-#  competition_id :integer
 #  name           :string
 #  position       :integer
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
+#  competition_id :integer
+#
+# Indexes
+#
+#  index_sponsorship_types_on_competition_id  (competition_id)
+#  index_sponsorship_types_on_position        (position)
 #
 
 # This model initially had no columns defined. If you add columns to the

--- a/test/fixtures/sponsorships.yml
+++ b/test/fixtures/sponsorships.yml
@@ -1,4 +1,16 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# == Schema Information
+#
+# Table name: sponsorships
+#
+#  id                  :bigint           not null, primary key
+#  sponsor_id          :integer
+#  sponsorship_type_id :integer
+#  sponsorable_type    :string
+#  sponsorable_id      :integer
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  approved            :boolean          default(FALSE)
+#
 
 # This model initially had no columns defined. If you add columns to the
 # model remove the '{}' from the fixture names and add the columns immediately

--- a/test/fixtures/sponsorships.yml
+++ b/test/fixtures/sponsorships.yml
@@ -3,13 +3,19 @@
 # Table name: sponsorships
 #
 #  id                  :bigint           not null, primary key
-#  sponsor_id          :integer
-#  sponsorship_type_id :integer
+#  approved            :boolean          default(FALSE)
 #  sponsorable_type    :string
-#  sponsorable_id      :integer
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
-#  approved            :boolean          default(FALSE)
+#  sponsor_id          :integer
+#  sponsorable_id      :integer
+#  sponsorship_type_id :integer
+#
+# Indexes
+#
+#  index_sponsorships_on_approved                             (approved)
+#  index_sponsorships_on_sponsor_id                           (sponsor_id)
+#  index_sponsorships_on_sponsorable_type_and_sponsorable_id  (sponsorable_type,sponsorable_id)
 #
 
 # This model initially had no columns defined. If you add columns to the

--- a/test/fixtures/team_data_sets.yml
+++ b/test/fixtures/team_data_sets.yml
@@ -3,13 +3,17 @@
 # Table name: team_data_sets
 #
 #  id                 :bigint           not null, primary key
-#  team_id            :integer
-#  name               :string
 #  description        :text
 #  description_of_use :text
+#  name               :string
 #  url                :string
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
+#  team_id            :integer
+#
+# Indexes
+#
+#  index_team_data_sets_on_team_id  (team_id)
 #
 
 one:

--- a/test/fixtures/team_data_sets.yml
+++ b/test/fixtures/team_data_sets.yml
@@ -1,4 +1,16 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# == Schema Information
+#
+# Table name: team_data_sets
+#
+#  id                 :bigint           not null, primary key
+#  team_id            :integer
+#  name               :string
+#  description        :text
+#  description_of_use :text
+#  url                :string
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#
 
 one:
   team: one

--- a/test/fixtures/teams.yml
+++ b/test/fixtures/teams.yml
@@ -3,14 +3,20 @@
 # Table name: teams
 #
 #  id                 :bigint           not null, primary key
-#  event_id           :integer
-#  project_id         :integer
+#  published          :boolean          default(TRUE)
+#  slack_channel_name :string
+#  youth_team         :boolean          default(FALSE)
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
-#  published          :boolean          default(TRUE)
-#  youth_team         :boolean          default(FALSE)
+#  event_id           :integer
+#  project_id         :integer
 #  slack_channel_id   :string
-#  slack_channel_name :string
+#
+# Indexes
+#
+#  index_teams_on_event_id    (event_id)
+#  index_teams_on_project_id  (project_id)
+#  index_teams_on_published   (published)
 #
 
 # This model initially had no columns defined. If you add columns to the

--- a/test/fixtures/teams.yml
+++ b/test/fixtures/teams.yml
@@ -1,4 +1,17 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# == Schema Information
+#
+# Table name: teams
+#
+#  id                 :bigint           not null, primary key
+#  event_id           :integer
+#  project_id         :integer
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  published          :boolean          default(TRUE)
+#  youth_team         :boolean          default(FALSE)
+#  slack_channel_id   :string
+#  slack_channel_name :string
+#
 
 # This model initially had no columns defined. If you add columns to the
 # model remove the '{}' from the fixture names and add the columns immediately

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,4 +1,55 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# == Schema Information
+#
+# Table name: users
+#
+#  id                              :bigint           not null, primary key
+#  email                           :string           default(""), not null
+#  encrypted_password              :string           default(""), not null
+#  full_name                       :string           default(""), not null
+#  preferred_name                  :string
+#  preferred_img                   :string
+#  google_img                      :string
+#  dietary_requirements            :text
+#  tshirt_size                     :string
+#  mailing_list                    :boolean          default(FALSE)
+#  challenge_sponsor_contact_place :boolean          default(FALSE)
+#  challenge_sponsor_contact_enter :boolean          default(FALSE)
+#  my_project_sponsor_contact      :boolean          default(FALSE)
+#  me_govhack_contact              :boolean          default(FALSE)
+#  reset_password_token            :string
+#  reset_password_sent_at          :datetime
+#  remember_created_at             :datetime
+#  sign_in_count                   :integer          default(0), not null
+#  current_sign_in_at              :datetime
+#  last_sign_in_at                 :datetime
+#  current_sign_in_ip              :inet
+#  last_sign_in_ip                 :inet
+#  confirmation_token              :string
+#  confirmed_at                    :datetime
+#  confirmation_sent_at            :datetime
+#  unconfirmed_email               :string
+#  failed_attempts                 :integer          default(0), not null
+#  unlock_token                    :string
+#  locked_at                       :datetime
+#  created_at                      :datetime         not null
+#  updated_at                      :datetime         not null
+#  organisation_name               :string
+#  phone_number                    :string
+#  how_did_you_hear                :text
+#  accepted_terms_and_conditions   :boolean
+#  registration_type               :string
+#  parent_guardian                 :string
+#  request_not_photographed        :boolean          default(FALSE)
+#  data_cruncher                   :boolean          default(FALSE)
+#  coder                           :boolean          default(FALSE)
+#  creative                        :boolean          default(FALSE)
+#  facilitator                     :boolean          default(FALSE)
+#  slack                           :string
+#  accepted_code_of_conduct        :datetime
+#  under_18                        :boolean
+#  region                          :integer
+#  acting_on_behalf_of_id          :integer
+#
 
 # This model initially had no columns defined. If you add columns to the
 # model remove the '{}' from the fixture names and add the columns immediately

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -3,52 +3,61 @@
 # Table name: users
 #
 #  id                              :bigint           not null, primary key
-#  email                           :string           default(""), not null
-#  encrypted_password              :string           default(""), not null
-#  full_name                       :string           default(""), not null
-#  preferred_name                  :string
-#  preferred_img                   :string
-#  google_img                      :string
-#  dietary_requirements            :text
-#  tshirt_size                     :string
-#  mailing_list                    :boolean          default(FALSE)
-#  challenge_sponsor_contact_place :boolean          default(FALSE)
+#  accepted_code_of_conduct        :datetime
+#  accepted_terms_and_conditions   :boolean
 #  challenge_sponsor_contact_enter :boolean          default(FALSE)
-#  my_project_sponsor_contact      :boolean          default(FALSE)
-#  me_govhack_contact              :boolean          default(FALSE)
-#  reset_password_token            :string
-#  reset_password_sent_at          :datetime
-#  remember_created_at             :datetime
-#  sign_in_count                   :integer          default(0), not null
-#  current_sign_in_at              :datetime
-#  last_sign_in_at                 :datetime
-#  current_sign_in_ip              :inet
-#  last_sign_in_ip                 :inet
+#  challenge_sponsor_contact_place :boolean          default(FALSE)
+#  coder                           :boolean          default(FALSE)
+#  confirmation_sent_at            :datetime
 #  confirmation_token              :string
 #  confirmed_at                    :datetime
-#  confirmation_sent_at            :datetime
-#  unconfirmed_email               :string
+#  creative                        :boolean          default(FALSE)
+#  current_sign_in_at              :datetime
+#  current_sign_in_ip              :inet
+#  data_cruncher                   :boolean          default(FALSE)
+#  dietary_requirements            :text
+#  email                           :string           default(""), not null
+#  encrypted_password              :string           default(""), not null
+#  facilitator                     :boolean          default(FALSE)
 #  failed_attempts                 :integer          default(0), not null
-#  unlock_token                    :string
+#  full_name                       :string           default(""), not null
+#  google_img                      :string
+#  how_did_you_hear                :text
+#  last_sign_in_at                 :datetime
+#  last_sign_in_ip                 :inet
 #  locked_at                       :datetime
+#  mailing_list                    :boolean          default(FALSE)
+#  me_govhack_contact              :boolean          default(FALSE)
+#  my_project_sponsor_contact      :boolean          default(FALSE)
+#  organisation_name               :string
+#  parent_guardian                 :string
+#  phone_number                    :string
+#  preferred_img                   :string
+#  preferred_name                  :string
+#  region                          :integer
+#  registration_type               :string
+#  remember_created_at             :datetime
+#  request_not_photographed        :boolean          default(FALSE)
+#  reset_password_sent_at          :datetime
+#  reset_password_token            :string
+#  sign_in_count                   :integer          default(0), not null
+#  slack                           :string
+#  tshirt_size                     :string
+#  unconfirmed_email               :string
+#  under_18                        :boolean
+#  unlock_token                    :string
 #  created_at                      :datetime         not null
 #  updated_at                      :datetime         not null
-#  organisation_name               :string
-#  phone_number                    :string
-#  how_did_you_hear                :text
-#  accepted_terms_and_conditions   :boolean
-#  registration_type               :string
-#  parent_guardian                 :string
-#  request_not_photographed        :boolean          default(FALSE)
-#  data_cruncher                   :boolean          default(FALSE)
-#  coder                           :boolean          default(FALSE)
-#  creative                        :boolean          default(FALSE)
-#  facilitator                     :boolean          default(FALSE)
-#  slack                           :string
-#  accepted_code_of_conduct        :datetime
-#  under_18                        :boolean
-#  region                          :integer
 #  acting_on_behalf_of_id          :integer
+#
+# Indexes
+#
+#  index_users_on_confirmation_token    (confirmation_token) UNIQUE
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_region                (region)
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#  index_users_on_under_18              (under_18)
+#  index_users_on_unlock_token          (unlock_token) UNIQUE
 #
 
 # This model initially had no columns defined. If you add columns to the

--- a/test/fixtures/visits.yml
+++ b/test/fixtures/visits.yml
@@ -1,4 +1,15 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# == Schema Information
+#
+# Table name: visits
+#
+#  id             :bigint           not null, primary key
+#  visitable_type :string           not null
+#  visitable_id   :bigint           not null
+#  user_id        :bigint
+#  competition_id :bigint           not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#
 
 resource:
   visitable: one (Resource)

--- a/test/fixtures/visits.yml
+++ b/test/fixtures/visits.yml
@@ -4,11 +4,22 @@
 #
 #  id             :bigint           not null, primary key
 #  visitable_type :string           not null
-#  visitable_id   :bigint           not null
-#  user_id        :bigint
-#  competition_id :bigint           not null
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
+#  competition_id :bigint           not null
+#  user_id        :bigint
+#  visitable_id   :bigint           not null
+#
+# Indexes
+#
+#  index_visits_on_competition_id  (competition_id)
+#  index_visits_on_user_id         (user_id)
+#  index_visits_on_visitable       (visitable_type,visitable_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (competition_id => competitions.id)
+#  fk_rails_...  (user_id => users.id)
 #
 
 resource:

--- a/test/models/assignment_test.rb
+++ b/test/models/assignment_test.rb
@@ -3,14 +3,22 @@
 # Table name: assignments
 #
 #  id              :bigint           not null, primary key
-#  user_id         :integer
 #  assignable_type :string
-#  assignable_id   :integer
 #  title           :string
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
+#  assignable_id   :integer
 #  competition_id  :integer
 #  holder_id       :integer
+#  user_id         :integer
+#
+# Indexes
+#
+#  index_assignments_on_assignable_type_and_assignable_id  (assignable_type,assignable_id)
+#  index_assignments_on_competition_id                     (competition_id)
+#  index_assignments_on_holder_id                          (holder_id)
+#  index_assignments_on_title                              (title)
+#  index_assignments_on_user_id                            (user_id)
 #
 require 'test_helper'
 

--- a/test/models/assignment_test.rb
+++ b/test/models/assignment_test.rb
@@ -1,3 +1,17 @@
+# == Schema Information
+#
+# Table name: assignments
+#
+#  id              :bigint           not null, primary key
+#  user_id         :integer
+#  assignable_type :string
+#  assignable_id   :integer
+#  title           :string
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  competition_id  :integer
+#  holder_id       :integer
+#
 require 'test_helper'
 
 class AssignmentTest < ActiveSupport::TestCase

--- a/test/models/badge_test.rb
+++ b/test/models/badge_test.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: badges
+#
+#  id             :bigint           not null, primary key
+#  competition_id :integer
+#  name           :string
+#  identifier     :string
+#  capacity       :integer
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#
 require 'test_helper'
 
 class BadgeTest < ActiveSupport::TestCase

--- a/test/models/badge_test.rb
+++ b/test/models/badge_test.rb
@@ -3,12 +3,16 @@
 # Table name: badges
 #
 #  id             :bigint           not null, primary key
-#  competition_id :integer
-#  name           :string
-#  identifier     :string
 #  capacity       :integer
+#  identifier     :string
+#  name           :string
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
+#  competition_id :integer
+#
+# Indexes
+#
+#  index_badges_on_identifier  (identifier)
 #
 require 'test_helper'
 

--- a/test/models/challenge_data_set_test.rb
+++ b/test/models/challenge_data_set_test.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: challenge_data_sets
+#
+#  id           :bigint           not null, primary key
+#  challenge_id :integer
+#  data_set_id  :integer
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
 require 'test_helper'
 
 class ChallengeDataSetTest < ActiveSupport::TestCase

--- a/test/models/challenge_data_set_test.rb
+++ b/test/models/challenge_data_set_test.rb
@@ -3,10 +3,15 @@
 # Table name: challenge_data_sets
 #
 #  id           :bigint           not null, primary key
-#  challenge_id :integer
-#  data_set_id  :integer
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
+#  challenge_id :integer
+#  data_set_id  :integer
+#
+# Indexes
+#
+#  index_challenge_data_sets_on_challenge_id  (challenge_id)
+#  index_challenge_data_sets_on_data_set_id   (data_set_id)
 #
 require 'test_helper'
 

--- a/test/models/challenge_sponsorship_test.rb
+++ b/test/models/challenge_sponsorship_test.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: challenge_sponsorships
+#
+#  id           :bigint           not null, primary key
+#  challenge_id :integer
+#  sponsor_id   :integer
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  approved     :boolean          default(FALSE)
+#
 require 'test_helper'
 
 class ChallengeSponsorshipTest < ActiveSupport::TestCase

--- a/test/models/challenge_sponsorship_test.rb
+++ b/test/models/challenge_sponsorship_test.rb
@@ -3,11 +3,16 @@
 # Table name: challenge_sponsorships
 #
 #  id           :bigint           not null, primary key
-#  challenge_id :integer
-#  sponsor_id   :integer
+#  approved     :boolean          default(FALSE)
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
-#  approved     :boolean          default(FALSE)
+#  challenge_id :integer
+#  sponsor_id   :integer
+#
+# Indexes
+#
+#  index_challenge_sponsorships_on_challenge_id  (challenge_id)
+#  index_challenge_sponsorships_on_sponsor_id    (sponsor_id)
 #
 require 'test_helper'
 

--- a/test/models/challenge_test.rb
+++ b/test/models/challenge_test.rb
@@ -3,17 +3,24 @@
 # Table name: challenges
 #
 #  id          :bigint           not null, primary key
-#  region_id   :integer
-#  name        :string
-#  short_desc  :text
-#  long_desc   :text
-#  eligibility :text
-#  video_url   :string
 #  approved    :boolean          default(FALSE)
+#  eligibility :text
+#  identifier  :string
+#  long_desc   :text
+#  name        :string
+#  nation_wide :boolean
+#  short_desc  :text
+#  video_url   :string
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
-#  identifier  :string
-#  nation_wide :boolean
+#  region_id   :integer
+#
+# Indexes
+#
+#  index_challenges_on_approved     (approved)
+#  index_challenges_on_identifier   (identifier)
+#  index_challenges_on_nation_wide  (nation_wide)
+#  index_challenges_on_region_id    (region_id)
 #
 require 'test_helper'
 

--- a/test/models/challenge_test.rb
+++ b/test/models/challenge_test.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: challenges
+#
+#  id          :bigint           not null, primary key
+#  region_id   :integer
+#  name        :string
+#  short_desc  :text
+#  long_desc   :text
+#  eligibility :text
+#  video_url   :string
+#  approved    :boolean          default(FALSE)
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  identifier  :string
+#  nation_wide :boolean
+#
 require 'test_helper'
 
 class ChallengeTest < ActiveSupport::TestCase

--- a/test/models/checkpoint_test.rb
+++ b/test/models/checkpoint_test.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: checkpoints
+#
+#  id                      :bigint           not null, primary key
+#  competition_id          :integer
+#  end_time                :datetime
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  max_regional_challenges :integer
+#  max_national_challenges :integer
+#  name                    :string
+#
 require 'test_helper'
 
 class CheckpointTest < ActiveSupport::TestCase

--- a/test/models/checkpoint_test.rb
+++ b/test/models/checkpoint_test.rb
@@ -3,13 +3,17 @@
 # Table name: checkpoints
 #
 #  id                      :bigint           not null, primary key
-#  competition_id          :integer
 #  end_time                :datetime
+#  max_national_challenges :integer
+#  max_regional_challenges :integer
+#  name                    :string
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
-#  max_regional_challenges :integer
-#  max_national_challenges :integer
-#  name                    :string
+#  competition_id          :integer
+#
+# Indexes
+#
+#  index_checkpoints_on_competition_id  (competition_id)
 #
 require 'test_helper'
 

--- a/test/models/competition_test.rb
+++ b/test/models/competition_test.rb
@@ -1,3 +1,23 @@
+# == Schema Information
+#
+# Table name: competitions
+#
+#  id                      :bigint           not null, primary key
+#  year                    :integer
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  start_time              :datetime
+#  end_time                :datetime
+#  peoples_choice_start    :datetime
+#  peoples_choice_end      :datetime
+#  challenge_judging_start :datetime
+#  challenge_judging_end   :datetime
+#  current                 :boolean
+#  team_form_start         :datetime
+#  team_form_end           :datetime
+#  hunt_badge_id           :integer
+#  hunt_published          :boolean
+#
 require 'test_helper'
 
 class CompetitionTest < ActiveSupport::TestCase

--- a/test/models/competition_test.rb
+++ b/test/models/competition_test.rb
@@ -3,20 +3,25 @@
 # Table name: competitions
 #
 #  id                      :bigint           not null, primary key
+#  challenge_judging_end   :datetime
+#  challenge_judging_start :datetime
+#  current                 :boolean
+#  end_time                :datetime
+#  hunt_published          :boolean
+#  peoples_choice_end      :datetime
+#  peoples_choice_start    :datetime
+#  start_time              :datetime
+#  team_form_end           :datetime
+#  team_form_start         :datetime
 #  year                    :integer
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
-#  start_time              :datetime
-#  end_time                :datetime
-#  peoples_choice_start    :datetime
-#  peoples_choice_end      :datetime
-#  challenge_judging_start :datetime
-#  challenge_judging_end   :datetime
-#  current                 :boolean
-#  team_form_start         :datetime
-#  team_form_end           :datetime
 #  hunt_badge_id           :integer
-#  hunt_published          :boolean
+#
+# Indexes
+#
+#  index_competitions_on_current  (current)
+#  index_competitions_on_year     (year)
 #
 require 'test_helper'
 

--- a/test/models/criterion_test.rb
+++ b/test/models/criterion_test.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: criteria
+#
+#  id             :bigint           not null, primary key
+#  competition_id :integer
+#  description    :text
+#  category       :string
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  name           :string
+#
 require 'test_helper'
 
 class CriterionTest < ActiveSupport::TestCase

--- a/test/models/criterion_test.rb
+++ b/test/models/criterion_test.rb
@@ -3,12 +3,16 @@
 # Table name: criteria
 #
 #  id             :bigint           not null, primary key
-#  competition_id :integer
-#  description    :text
 #  category       :string
+#  description    :text
+#  name           :string
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
-#  name           :string
+#  competition_id :integer
+#
+# Indexes
+#
+#  index_criteria_on_competition_id  (competition_id)
 #
 require 'test_helper'
 

--- a/test/models/data_set_test.rb
+++ b/test/models/data_set_test.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: data_sets
+#
+#  id          :bigint           not null, primary key
+#  region_id   :integer
+#  name        :string
+#  url         :string
+#  description :text
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 require 'test_helper'
 
 class DataSetTest < ActiveSupport::TestCase

--- a/test/models/data_set_test.rb
+++ b/test/models/data_set_test.rb
@@ -3,12 +3,16 @@
 # Table name: data_sets
 #
 #  id          :bigint           not null, primary key
-#  region_id   :integer
+#  description :text
 #  name        :string
 #  url         :string
-#  description :text
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#  region_id   :integer
+#
+# Indexes
+#
+#  index_data_sets_on_region_id  (region_id)
 #
 require 'test_helper'
 

--- a/test/models/dataset_test.rb
+++ b/test/models/dataset_test.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: datasets
+#
+#  id          :bigint           not null, primary key
+#  name        :string
+#  url         :string
+#  description :text
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 require 'test_helper'
 
 class DatasetTest < ActiveSupport::TestCase

--- a/test/models/employment_status_test.rb
+++ b/test/models/employment_status_test.rb
@@ -1,3 +1,22 @@
+# == Schema Information
+#
+# Table name: employment_statuses
+#
+#  id                       :bigint           not null, primary key
+#  profile_id               :integer
+#  full_time_employed       :boolean
+#  part_time_casual         :boolean
+#  self_employed            :boolean
+#  full_time_student        :boolean
+#  part_time_student        :boolean
+#  not_employed_looking     :boolean
+#  not_employed_not_looking :boolean
+#  retired                  :boolean
+#  not_able_to_work         :boolean
+#  prefer_not_to_say        :boolean
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#
 require 'test_helper'
 
 class EmploymentStatusTest < ActiveSupport::TestCase

--- a/test/models/entry_test.rb
+++ b/test/models/entry_test.rb
@@ -3,14 +3,22 @@
 # Table name: entries
 #
 #  id            :bigint           not null, primary key
-#  team_id       :integer
-#  challenge_id  :integer
-#  checkpoint_id :integer
-#  justification :text
+#  award         :string
 #  eligible      :boolean
+#  justification :text
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
-#  award         :string
+#  challenge_id  :integer
+#  checkpoint_id :integer
+#  team_id       :integer
+#
+# Indexes
+#
+#  index_entries_on_award          (award)
+#  index_entries_on_challenge_id   (challenge_id)
+#  index_entries_on_checkpoint_id  (checkpoint_id)
+#  index_entries_on_eligible       (eligible)
+#  index_entries_on_team_id        (team_id)
 #
 require 'test_helper'
 

--- a/test/models/entry_test.rb
+++ b/test/models/entry_test.rb
@@ -1,3 +1,17 @@
+# == Schema Information
+#
+# Table name: entries
+#
+#  id            :bigint           not null, primary key
+#  team_id       :integer
+#  challenge_id  :integer
+#  checkpoint_id :integer
+#  justification :text
+#  eligible      :boolean
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  award         :string
+#
 require 'test_helper'
 
 class EntryTest < ActiveSupport::TestCase

--- a/test/models/event_partnership_test.rb
+++ b/test/models/event_partnership_test.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: event_partnerships
+#
+#  id         :bigint           not null, primary key
+#  event_id   :integer
+#  sponsor_id :integer
+#  approved   :boolean          default(FALSE)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 require 'test_helper'
 
 class EventPartnershipTest < ActiveSupport::TestCase

--- a/test/models/event_partnership_test.rb
+++ b/test/models/event_partnership_test.rb
@@ -3,11 +3,17 @@
 # Table name: event_partnerships
 #
 #  id         :bigint           not null, primary key
-#  event_id   :integer
-#  sponsor_id :integer
 #  approved   :boolean          default(FALSE)
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  event_id   :integer
+#  sponsor_id :integer
+#
+# Indexes
+#
+#  index_event_partnerships_on_approved    (approved)
+#  index_event_partnerships_on_event_id    (event_id)
+#  index_event_partnerships_on_sponsor_id  (sponsor_id)
 #
 require 'test_helper'
 

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -3,29 +3,35 @@
 # Table name: events
 #
 #  id                :bigint           not null, primary key
-#  region_id         :integer
-#  name              :string
-#  registration_type :string
-#  capacity          :integer
-#  email             :string
-#  twitter           :string
-#  address           :text
 #  accessibility     :text
-#  youth_support     :text
+#  address           :text
+#  capacity          :integer
+#  catering          :text
+#  description       :text
+#  email             :string
+#  end_time          :datetime
+#  event_type        :string
+#  identifier        :string
+#  name              :string
+#  operation_hours   :text
 #  parking           :text
 #  public_transport  :text
-#  operation_hours   :text
-#  catering          :text
-#  video_id          :string
-#  start_time        :datetime
-#  end_time          :datetime
 #  published         :boolean          default(FALSE)
+#  registration_type :string
+#  start_time        :datetime
+#  twitter           :string
+#  youth_support     :text
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  place_id          :string
-#  identifier        :string
-#  event_type        :string
-#  description       :text
+#  region_id         :integer
+#  video_id          :string
+#
+# Indexes
+#
+#  index_events_on_identifier  (identifier)
+#  index_events_on_published   (published)
+#  index_events_on_region_id   (region_id)
 #
 require 'test_helper'
 

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -1,3 +1,32 @@
+# == Schema Information
+#
+# Table name: events
+#
+#  id                :bigint           not null, primary key
+#  region_id         :integer
+#  name              :string
+#  registration_type :string
+#  capacity          :integer
+#  email             :string
+#  twitter           :string
+#  address           :text
+#  accessibility     :text
+#  youth_support     :text
+#  parking           :text
+#  public_transport  :text
+#  operation_hours   :text
+#  catering          :text
+#  video_id          :string
+#  start_time        :datetime
+#  end_time          :datetime
+#  published         :boolean          default(FALSE)
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  place_id          :string
+#  identifier        :string
+#  event_type        :string
+#  description       :text
+#
 require 'test_helper'
 
 class EventTest < ActiveSupport::TestCase

--- a/test/models/favourite_test.rb
+++ b/test/models/favourite_test.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: favourites
+#
+#  id            :bigint           not null, primary key
+#  assignment_id :integer
+#  team_id       :integer
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  holder_id     :integer
+#
 require 'test_helper'
 
 class FavouriteTest < ActiveSupport::TestCase

--- a/test/models/favourite_test.rb
+++ b/test/models/favourite_test.rb
@@ -3,11 +3,17 @@
 # Table name: favourites
 #
 #  id            :bigint           not null, primary key
-#  assignment_id :integer
-#  team_id       :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
+#  assignment_id :integer
 #  holder_id     :integer
+#  team_id       :integer
+#
+# Indexes
+#
+#  index_favourites_on_assignment_id  (assignment_id)
+#  index_favourites_on_holder_id      (holder_id)
+#  index_favourites_on_team_id        (team_id)
 #
 require 'test_helper'
 

--- a/test/models/header_test.rb
+++ b/test/models/header_test.rb
@@ -3,12 +3,18 @@
 # Table name: headers
 #
 #  id             :bigint           not null, primary key
-#  assignment_id  :integer
+#  included       :boolean          default(TRUE)
 #  scoreable_type :string
-#  scoreable_id   :bigint
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
-#  included       :boolean          default(TRUE)
+#  assignment_id  :integer
+#  scoreable_id   :bigint
+#
+# Indexes
+#
+#  index_headers_on_assignment_id                    (assignment_id)
+#  index_headers_on_included                         (included)
+#  index_headers_on_scoreable_type_and_scoreable_id  (scoreable_type,scoreable_id)
 #
 require 'test_helper'
 

--- a/test/models/header_test.rb
+++ b/test/models/header_test.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: headers
+#
+#  id             :bigint           not null, primary key
+#  assignment_id  :integer
+#  scoreable_type :string
+#  scoreable_id   :bigint
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  included       :boolean          default(TRUE)
+#
 require 'test_helper'
 
 class HeaderTest < ActiveSupport::TestCase

--- a/test/models/holder_test.rb
+++ b/test/models/holder_test.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: holders
+#
+#  id                    :bigint           not null, primary key
+#  user_id               :bigint           not null
+#  competition_id        :bigint           not null
+#  aws_credits_requested :boolean
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  team_status           :integer
+#  profile_id            :bigint
+#
 require 'test_helper'
 
 class HolderTest < ActiveSupport::TestCase

--- a/test/models/holder_test.rb
+++ b/test/models/holder_test.rb
@@ -3,13 +3,27 @@
 # Table name: holders
 #
 #  id                    :bigint           not null, primary key
-#  user_id               :bigint           not null
-#  competition_id        :bigint           not null
 #  aws_credits_requested :boolean
+#  team_status           :integer
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
-#  team_status           :integer
+#  competition_id        :bigint           not null
 #  profile_id            :bigint
+#  user_id               :bigint           not null
+#
+# Indexes
+#
+#  index_holders_on_aws_credits_requested  (aws_credits_requested)
+#  index_holders_on_competition_id         (competition_id)
+#  index_holders_on_profile_id             (profile_id)
+#  index_holders_on_team_status            (team_status)
+#  index_holders_on_user_id                (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (competition_id => competitions.id)
+#  fk_rails_...  (profile_id => profiles.id)
+#  fk_rails_...  (user_id => users.id)
 #
 require 'test_helper'
 

--- a/test/models/hunt_question_test.rb
+++ b/test/models/hunt_question_test.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: hunt_questions
+#
+#  id             :bigint           not null, primary key
+#  competition_id :integer
+#  question       :string
+#  answer         :string
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#
 require 'test_helper'
 
 class HuntQuestionTest < ActiveSupport::TestCase

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -1,3 +1,29 @@
+# == Schema Information
+#
+# Table name: profiles
+#
+#  id                 :bigint           not null, primary key
+#  user_id            :integer
+#  age                :integer
+#  gender             :string
+#  first_peoples      :integer
+#  disability         :integer
+#  education          :integer
+#  users              :string
+#  postcode           :string
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  identifier         :string
+#  team_status        :integer
+#  website            :string
+#  linkedin           :string
+#  twitter            :string
+#  description        :string
+#  github             :string
+#  published          :boolean
+#  slack_user_id      :string
+#  slack_access_token :string
+#
 require 'test_helper'
 
 class ProfileTest < ActiveSupport::TestCase

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -3,26 +3,30 @@
 # Table name: profiles
 #
 #  id                 :bigint           not null, primary key
-#  user_id            :integer
 #  age                :integer
-#  gender             :string
-#  first_peoples      :integer
+#  description        :string
 #  disability         :integer
 #  education          :integer
-#  users              :string
+#  first_peoples      :integer
+#  gender             :string
+#  github             :string
+#  identifier         :string
+#  linkedin           :string
 #  postcode           :string
+#  published          :boolean
+#  slack_access_token :string
+#  team_status        :integer
+#  twitter            :string
+#  users              :string
+#  website            :string
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
-#  identifier         :string
-#  team_status        :integer
-#  website            :string
-#  linkedin           :string
-#  twitter            :string
-#  description        :string
-#  github             :string
-#  published          :boolean
 #  slack_user_id      :string
-#  slack_access_token :string
+#  user_id            :integer
+#
+# Indexes
+#
+#  index_profiles_on_identifier  (identifier)
 #
 require 'test_helper'
 

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -3,18 +3,24 @@
 # Table name: projects
 #
 #  id              :bigint           not null, primary key
-#  team_id         :integer
-#  team_name       :string
-#  description     :text
 #  data_story      :text
-#  source_code_url :string
-#  video_url       :string
+#  description     :text
 #  homepage_url    :string
+#  identifier      :string
+#  project_name    :string
+#  source_code_url :string
+#  team_name       :string
+#  video_url       :string
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
+#  team_id         :integer
 #  user_id         :integer
-#  project_name    :string
-#  identifier      :string
+#
+# Indexes
+#
+#  index_projects_on_identifier  (identifier)
+#  index_projects_on_team_id     (team_id)
+#  index_projects_on_user_id     (user_id)
 #
 require 'test_helper'
 

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -1,3 +1,21 @@
+# == Schema Information
+#
+# Table name: projects
+#
+#  id              :bigint           not null, primary key
+#  team_id         :integer
+#  team_name       :string
+#  description     :text
+#  data_story      :text
+#  source_code_url :string
+#  video_url       :string
+#  homepage_url    :string
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  user_id         :integer
+#  project_name    :string
+#  identifier      :string
+#
 require 'test_helper'
 
 class ProjectTest < ActiveSupport::TestCase

--- a/test/models/region_limit_test.rb
+++ b/test/models/region_limit_test.rb
@@ -3,12 +3,17 @@
 # Table name: region_limits
 #
 #  id                      :bigint           not null, primary key
-#  region_id               :integer
-#  checkpoint_id           :integer
-#  max_regional_challenges :integer
 #  max_national_challenges :integer
+#  max_regional_challenges :integer
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
+#  checkpoint_id           :integer
+#  region_id               :integer
+#
+# Indexes
+#
+#  index_region_limits_on_checkpoint_id  (checkpoint_id)
+#  index_region_limits_on_region_id      (region_id)
 #
 require 'test_helper'
 

--- a/test/models/region_limit_test.rb
+++ b/test/models/region_limit_test.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: region_limits
+#
+#  id                      :bigint           not null, primary key
+#  region_id               :integer
+#  checkpoint_id           :integer
+#  max_regional_challenges :integer
+#  max_national_challenges :integer
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#
 require 'test_helper'
 
 class RegionLimitTest < ActiveSupport::TestCase

--- a/test/models/region_test.rb
+++ b/test/models/region_test.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: regions
+#
+#  id             :bigint           not null, primary key
+#  name           :string
+#  time_zone      :string
+#  parent_id      :integer
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  award_release  :datetime
+#  competition_id :integer
+#  category       :string
+#  identifier     :string
+#
 require 'test_helper'
 
 class RegionTest < ActiveSupport::TestCase

--- a/test/models/region_test.rb
+++ b/test/models/region_test.rb
@@ -3,15 +3,21 @@
 # Table name: regions
 #
 #  id             :bigint           not null, primary key
-#  name           :string
-#  time_zone      :string
-#  parent_id      :integer
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
 #  award_release  :datetime
-#  competition_id :integer
 #  category       :string
 #  identifier     :string
+#  name           :string
+#  time_zone      :string
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  competition_id :integer
+#  parent_id      :integer
+#
+# Indexes
+#
+#  index_regions_on_competition_id  (competition_id)
+#  index_regions_on_identifier      (identifier)
+#  index_regions_on_parent_id       (parent_id)
 #
 require 'test_helper'
 

--- a/test/models/registration_test.rb
+++ b/test/models/registration_test.rb
@@ -3,13 +3,20 @@
 # Table name: registrations
 #
 #  id            :bigint           not null, primary key
-#  assignment_id :integer
-#  time_notified :datetime
 #  status        :string
+#  time_notified :datetime
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
+#  assignment_id :integer
 #  event_id      :integer
 #  holder_id     :integer
+#
+# Indexes
+#
+#  index_registrations_on_assignment_id  (assignment_id)
+#  index_registrations_on_event_id       (event_id)
+#  index_registrations_on_holder_id      (holder_id)
+#  index_registrations_on_status         (status)
 #
 require 'test_helper'
 

--- a/test/models/registration_test.rb
+++ b/test/models/registration_test.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: registrations
+#
+#  id            :bigint           not null, primary key
+#  assignment_id :integer
+#  time_notified :datetime
+#  status        :string
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  event_id      :integer
+#  holder_id     :integer
+#
 require 'test_helper'
 
 class RegistrationTest < ActiveSupport::TestCase

--- a/test/models/resource_test.rb
+++ b/test/models/resource_test.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: resources
+#
+#  id                 :bigint           not null, primary key
+#  competition_id     :integer
+#  category           :integer
+#  position           :integer
+#  url                :string
+#  name               :string
+#  short_url          :string
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  show_on_front_page :boolean
+#
 require 'test_helper'
 
 class ResourceTest < ActiveSupport::TestCase

--- a/test/models/resource_test.rb
+++ b/test/models/resource_test.rb
@@ -3,15 +3,19 @@
 # Table name: resources
 #
 #  id                 :bigint           not null, primary key
-#  competition_id     :integer
 #  category           :integer
-#  position           :integer
-#  url                :string
 #  name               :string
+#  position           :integer
 #  short_url          :string
+#  show_on_front_page :boolean
+#  url                :string
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
-#  show_on_front_page :boolean
+#  competition_id     :integer
+#
+# Indexes
+#
+#  index_resources_on_show_on_front_page  (show_on_front_page)
 #
 require 'test_helper'
 

--- a/test/models/score_test.rb
+++ b/test/models/score_test.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: scores
+#
+#  id           :bigint           not null, primary key
+#  header_id    :integer
+#  criterion_id :integer
+#  entry        :integer
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
 require 'test_helper'
 
 class ScoreTest < ActiveSupport::TestCase

--- a/test/models/score_test.rb
+++ b/test/models/score_test.rb
@@ -3,11 +3,16 @@
 # Table name: scores
 #
 #  id           :bigint           not null, primary key
-#  header_id    :integer
-#  criterion_id :integer
 #  entry        :integer
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
+#  criterion_id :integer
+#  header_id    :integer
+#
+# Indexes
+#
+#  index_scores_on_criterion_id  (criterion_id)
+#  index_scores_on_header_id     (header_id)
 #
 require 'test_helper'
 

--- a/test/models/sponsor_test.rb
+++ b/test/models/sponsor_test.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: sponsors
+#
+#  id             :bigint           not null, primary key
+#  name           :string
+#  description    :text
+#  url            :string
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  competition_id :integer
+#
 require 'test_helper'
 
 class SponsorTest < ActiveSupport::TestCase

--- a/test/models/sponsor_test.rb
+++ b/test/models/sponsor_test.rb
@@ -3,12 +3,16 @@
 # Table name: sponsors
 #
 #  id             :bigint           not null, primary key
-#  name           :string
 #  description    :text
+#  name           :string
 #  url            :string
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #  competition_id :integer
+#
+# Indexes
+#
+#  index_sponsors_on_competition_id  (competition_id)
 #
 require 'test_helper'
 

--- a/test/models/sponsorship_test.rb
+++ b/test/models/sponsorship_test.rb
@@ -3,13 +3,19 @@
 # Table name: sponsorships
 #
 #  id                  :bigint           not null, primary key
-#  sponsor_id          :integer
-#  sponsorship_type_id :integer
+#  approved            :boolean          default(FALSE)
 #  sponsorable_type    :string
-#  sponsorable_id      :integer
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
-#  approved            :boolean          default(FALSE)
+#  sponsor_id          :integer
+#  sponsorable_id      :integer
+#  sponsorship_type_id :integer
+#
+# Indexes
+#
+#  index_sponsorships_on_approved                             (approved)
+#  index_sponsorships_on_sponsor_id                           (sponsor_id)
+#  index_sponsorships_on_sponsorable_type_and_sponsorable_id  (sponsorable_type,sponsorable_id)
 #
 require 'test_helper'
 

--- a/test/models/sponsorship_test.rb
+++ b/test/models/sponsorship_test.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: sponsorships
+#
+#  id                  :bigint           not null, primary key
+#  sponsor_id          :integer
+#  sponsorship_type_id :integer
+#  sponsorable_type    :string
+#  sponsorable_id      :integer
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  approved            :boolean          default(FALSE)
+#
 require 'test_helper'
 
 class SponsorshipTest < ActiveSupport::TestCase

--- a/test/models/sponsorship_type_test.rb
+++ b/test/models/sponsorship_type_test.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: sponsorship_types
+#
+#  id             :bigint           not null, primary key
+#  competition_id :integer
+#  name           :string
+#  position       :integer
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#
 require 'test_helper'
 
 class SponsorshipTypeTest < ActiveSupport::TestCase

--- a/test/models/sponsorship_type_test.rb
+++ b/test/models/sponsorship_type_test.rb
@@ -3,11 +3,16 @@
 # Table name: sponsorship_types
 #
 #  id             :bigint           not null, primary key
-#  competition_id :integer
 #  name           :string
 #  position       :integer
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
+#  competition_id :integer
+#
+# Indexes
+#
+#  index_sponsorship_types_on_competition_id  (competition_id)
+#  index_sponsorship_types_on_position        (position)
 #
 require 'test_helper'
 

--- a/test/models/team_data_set_test.rb
+++ b/test/models/team_data_set_test.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: team_data_sets
+#
+#  id                 :bigint           not null, primary key
+#  team_id            :integer
+#  name               :string
+#  description        :text
+#  description_of_use :text
+#  url                :string
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#
 require 'test_helper'
 
 class TeamDataSetTest < ActiveSupport::TestCase

--- a/test/models/team_data_set_test.rb
+++ b/test/models/team_data_set_test.rb
@@ -3,13 +3,17 @@
 # Table name: team_data_sets
 #
 #  id                 :bigint           not null, primary key
-#  team_id            :integer
-#  name               :string
 #  description        :text
 #  description_of_use :text
+#  name               :string
 #  url                :string
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
+#  team_id            :integer
+#
+# Indexes
+#
+#  index_team_data_sets_on_team_id  (team_id)
 #
 require 'test_helper'
 

--- a/test/models/team_test.rb
+++ b/test/models/team_test.rb
@@ -1,3 +1,17 @@
+# == Schema Information
+#
+# Table name: teams
+#
+#  id                 :bigint           not null, primary key
+#  event_id           :integer
+#  project_id         :integer
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  published          :boolean          default(TRUE)
+#  youth_team         :boolean          default(FALSE)
+#  slack_channel_id   :string
+#  slack_channel_name :string
+#
 require 'test_helper'
 
 class TeamTest < ActiveSupport::TestCase

--- a/test/models/team_test.rb
+++ b/test/models/team_test.rb
@@ -3,14 +3,20 @@
 # Table name: teams
 #
 #  id                 :bigint           not null, primary key
-#  event_id           :integer
-#  project_id         :integer
+#  published          :boolean          default(TRUE)
+#  slack_channel_name :string
+#  youth_team         :boolean          default(FALSE)
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
-#  published          :boolean          default(TRUE)
-#  youth_team         :boolean          default(FALSE)
+#  event_id           :integer
+#  project_id         :integer
 #  slack_channel_id   :string
-#  slack_channel_name :string
+#
+# Indexes
+#
+#  index_teams_on_event_id    (event_id)
+#  index_teams_on_project_id  (project_id)
+#  index_teams_on_published   (published)
 #
 require 'test_helper'
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,3 +1,55 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                              :bigint           not null, primary key
+#  email                           :string           default(""), not null
+#  encrypted_password              :string           default(""), not null
+#  full_name                       :string           default(""), not null
+#  preferred_name                  :string
+#  preferred_img                   :string
+#  google_img                      :string
+#  dietary_requirements            :text
+#  tshirt_size                     :string
+#  mailing_list                    :boolean          default(FALSE)
+#  challenge_sponsor_contact_place :boolean          default(FALSE)
+#  challenge_sponsor_contact_enter :boolean          default(FALSE)
+#  my_project_sponsor_contact      :boolean          default(FALSE)
+#  me_govhack_contact              :boolean          default(FALSE)
+#  reset_password_token            :string
+#  reset_password_sent_at          :datetime
+#  remember_created_at             :datetime
+#  sign_in_count                   :integer          default(0), not null
+#  current_sign_in_at              :datetime
+#  last_sign_in_at                 :datetime
+#  current_sign_in_ip              :inet
+#  last_sign_in_ip                 :inet
+#  confirmation_token              :string
+#  confirmed_at                    :datetime
+#  confirmation_sent_at            :datetime
+#  unconfirmed_email               :string
+#  failed_attempts                 :integer          default(0), not null
+#  unlock_token                    :string
+#  locked_at                       :datetime
+#  created_at                      :datetime         not null
+#  updated_at                      :datetime         not null
+#  organisation_name               :string
+#  phone_number                    :string
+#  how_did_you_hear                :text
+#  accepted_terms_and_conditions   :boolean
+#  registration_type               :string
+#  parent_guardian                 :string
+#  request_not_photographed        :boolean          default(FALSE)
+#  data_cruncher                   :boolean          default(FALSE)
+#  coder                           :boolean          default(FALSE)
+#  creative                        :boolean          default(FALSE)
+#  facilitator                     :boolean          default(FALSE)
+#  slack                           :string
+#  accepted_code_of_conduct        :datetime
+#  under_18                        :boolean
+#  region                          :integer
+#  acting_on_behalf_of_id          :integer
+#
 require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -3,52 +3,61 @@
 # Table name: users
 #
 #  id                              :bigint           not null, primary key
-#  email                           :string           default(""), not null
-#  encrypted_password              :string           default(""), not null
-#  full_name                       :string           default(""), not null
-#  preferred_name                  :string
-#  preferred_img                   :string
-#  google_img                      :string
-#  dietary_requirements            :text
-#  tshirt_size                     :string
-#  mailing_list                    :boolean          default(FALSE)
-#  challenge_sponsor_contact_place :boolean          default(FALSE)
+#  accepted_code_of_conduct        :datetime
+#  accepted_terms_and_conditions   :boolean
 #  challenge_sponsor_contact_enter :boolean          default(FALSE)
-#  my_project_sponsor_contact      :boolean          default(FALSE)
-#  me_govhack_contact              :boolean          default(FALSE)
-#  reset_password_token            :string
-#  reset_password_sent_at          :datetime
-#  remember_created_at             :datetime
-#  sign_in_count                   :integer          default(0), not null
-#  current_sign_in_at              :datetime
-#  last_sign_in_at                 :datetime
-#  current_sign_in_ip              :inet
-#  last_sign_in_ip                 :inet
+#  challenge_sponsor_contact_place :boolean          default(FALSE)
+#  coder                           :boolean          default(FALSE)
+#  confirmation_sent_at            :datetime
 #  confirmation_token              :string
 #  confirmed_at                    :datetime
-#  confirmation_sent_at            :datetime
-#  unconfirmed_email               :string
+#  creative                        :boolean          default(FALSE)
+#  current_sign_in_at              :datetime
+#  current_sign_in_ip              :inet
+#  data_cruncher                   :boolean          default(FALSE)
+#  dietary_requirements            :text
+#  email                           :string           default(""), not null
+#  encrypted_password              :string           default(""), not null
+#  facilitator                     :boolean          default(FALSE)
 #  failed_attempts                 :integer          default(0), not null
-#  unlock_token                    :string
+#  full_name                       :string           default(""), not null
+#  google_img                      :string
+#  how_did_you_hear                :text
+#  last_sign_in_at                 :datetime
+#  last_sign_in_ip                 :inet
 #  locked_at                       :datetime
+#  mailing_list                    :boolean          default(FALSE)
+#  me_govhack_contact              :boolean          default(FALSE)
+#  my_project_sponsor_contact      :boolean          default(FALSE)
+#  organisation_name               :string
+#  parent_guardian                 :string
+#  phone_number                    :string
+#  preferred_img                   :string
+#  preferred_name                  :string
+#  region                          :integer
+#  registration_type               :string
+#  remember_created_at             :datetime
+#  request_not_photographed        :boolean          default(FALSE)
+#  reset_password_sent_at          :datetime
+#  reset_password_token            :string
+#  sign_in_count                   :integer          default(0), not null
+#  slack                           :string
+#  tshirt_size                     :string
+#  unconfirmed_email               :string
+#  under_18                        :boolean
+#  unlock_token                    :string
 #  created_at                      :datetime         not null
 #  updated_at                      :datetime         not null
-#  organisation_name               :string
-#  phone_number                    :string
-#  how_did_you_hear                :text
-#  accepted_terms_and_conditions   :boolean
-#  registration_type               :string
-#  parent_guardian                 :string
-#  request_not_photographed        :boolean          default(FALSE)
-#  data_cruncher                   :boolean          default(FALSE)
-#  coder                           :boolean          default(FALSE)
-#  creative                        :boolean          default(FALSE)
-#  facilitator                     :boolean          default(FALSE)
-#  slack                           :string
-#  accepted_code_of_conduct        :datetime
-#  under_18                        :boolean
-#  region                          :integer
 #  acting_on_behalf_of_id          :integer
+#
+# Indexes
+#
+#  index_users_on_confirmation_token    (confirmation_token) UNIQUE
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_region                (region)
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#  index_users_on_under_18              (under_18)
+#  index_users_on_unlock_token          (unlock_token) UNIQUE
 #
 require 'test_helper'
 

--- a/test/models/visit_test.rb
+++ b/test/models/visit_test.rb
@@ -4,11 +4,22 @@
 #
 #  id             :bigint           not null, primary key
 #  visitable_type :string           not null
-#  visitable_id   :bigint           not null
-#  user_id        :bigint
-#  competition_id :bigint           not null
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
+#  competition_id :bigint           not null
+#  user_id        :bigint
+#  visitable_id   :bigint           not null
+#
+# Indexes
+#
+#  index_visits_on_competition_id  (competition_id)
+#  index_visits_on_user_id         (user_id)
+#  index_visits_on_visitable       (visitable_type,visitable_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (competition_id => competitions.id)
+#  fk_rails_...  (user_id => users.id)
 #
 require 'test_helper'
 

--- a/test/models/visit_test.rb
+++ b/test/models/visit_test.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: visits
+#
+#  id             :bigint           not null, primary key
+#  visitable_type :string           not null
+#  visitable_id   :bigint           not null
+#  user_id        :bigint
+#  competition_id :bigint           not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#
 require 'test_helper'
 
 class VisitTest < ActiveSupport::TestCase


### PR DESCRIPTION
## Why

Annotations are helpful when developing in a new codebase. They aid by adding a very short commented out blurb to each model (factories/serializers/etc...) file. This gives developers a quick way to see what columns and indexes a table has.

## What 

Adds the annotate gem
Runs `annotate --models` to generate annotations

## Pull Request Checklist

Signed-off-by: Blake Astley <astley92@hotmail.com>

* [x] Pull request is based on the `main` branch
* [x] Pull request includes a [sign off](../CONTRIBUTING.md#sign-off)
