### PR TITLE
Add healthcheck endpoint

### DIFF
--- a/app/controllers/api/v1/health_controller.rb
+++ b/app/controllers/api/v1/health_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class API::V1::HealthController < API::V1::BaseController
+  def show
+    render json: {data: {version: ENV.fetch('COMMIT_SHA', 'unknown')}}
+  end
+end

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -1,5 +1,7 @@
 namespace :api do
   namespace :v1 do
+    get "/health", to: "health#show"
+
     resources :projects, only: [:index]
   end
 end

--- a/spec/requests/api/v1/health_check_spec.rb
+++ b/spec/requests/api/v1/health_check_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+RSpec.describe '/api/v1/health' do
+  it 'returns the expected response' do
+    get '/api/v1/health'
+
+    expect(response).to have_http_status(:success)
+    parsed_body = JSON.parse(response.body, symbolize_names: true)
+
+    expect(parsed_body.fetch(:data)).to eq(
+      {
+        version: 'unknown',
+      },
+    )
+  end
+
+  context 'when the COMMIT_SHA environment variable is set' do
+    around do |example|
+      original_value = ENV.fetch('COMMIT_SHA', nil)
+      ENV['COMMIT_SHA'] = '797754ec826c9c31591ae409b8f4ca9d7a98ac89'
+      example.run
+      ENV['COMMIT_SHA'] = original_value
+    end
+
+    it 'returns the expected response' do
+      get '/api/v1/health'
+
+      expect(response).to have_http_status(:success)
+      parsed_body = JSON.parse(response.body, symbolize_names: true)
+
+      expect(parsed_body.fetch(:data)).to eq(
+        {
+          version: '797754ec826c9c31591ae409b8f4ca9d7a98ac89',
+        },
+      )
+    end
+  end
+end


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the `main` branch
* [x] Pull request includes a [sign off](../CONTRIBUTING.md#sign-off)

<!-- SIGN OFF -->
<!-- Uncomment below and fill in your details to sign off this PR -->
Signed-off-by: Blake Astley <astley92@hotmail.com>

### Details

Adds one new endpoint `/api/v1/health` that simply returns a 200 and the current application versions git sha if it is set.

Is an environment variable where we think this would come from?
