### PR TITLE
fix hardcoded date on competition events page

### DIFF
--- a/app/views/competition_events/_competition_event_side.html.erb
+++ b/app/views/competition_events/_competition_event_side.html.erb
@@ -13,6 +13,6 @@
 </div>
 <div class="event-info">
   <h4>Challenges Open</h4>
-  <p>7pm <%= start_weekday_name %> <%= start_day %> <%= start_month %></p>
+  <p><%= @competition.start_time.strftime("%l%P %A %e %B").strip %></p>
   <p>(Local Times)</p>
 </div>

--- a/app/views/competition_events/_competition_event_side.html.erb
+++ b/app/views/competition_events/_competition_event_side.html.erb
@@ -1,5 +1,6 @@
 <% start_day = @competition.start_time.day.ordinalize %>
 <% end_day = @competition.end_time.day.ordinalize %>
+<% start_weekday_name = @competition.start_time.strftime("%A") %>
 
 <% start_month = @competition.start_time.strftime("%B") %>
 <% end_month = @competition.end_time.strftime("%B") %>
@@ -12,6 +13,6 @@
 </div>
 <div class="event-info">
   <h4>Challenges Open</h4>
-  <p>7pm Friday 19th August</p>
+  <p>7pm <%= start_weekday_name %> <%= start_day %> <%= start_month %></p>
   <p>(Local Times)</p>
 </div>


### PR DESCRIPTION
Fixes #417 

### Pull Request Checklist

* [x] Pull request is based on the `main` branch
* [x] Pull request includes a [sign off](../CONTRIBUTING.md#sign-off)

Signed-off-by: Benjamin Pickford <benjamin@govhack.org>

### Testing
Confirmed it uses date format from DB

![image](https://github.com/govhackaustralia/hackerspace3/assets/12684286/58ac201e-105c-4a0c-8b7b-ab1f43528dc3)
