### PR TITLE
Fix Docker builds by switching package repositories to "archive" because OS image is EOL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
 FROM ruby:3.0.0
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-    postgresql-client \
-    && rm -rf /var/lib/apt/lists/*
+# Switch package repositories to "archive" because the OS image based on Ruby 3.0.0 is EOL (End Of Life)
+# Based on https://unix.stackexchange.com/questions/743839/apt-get-update-failed-to-fetch-debian-amd64-packages-while-building-dockerfile-f
+RUN sed -i s/deb.debian.org/archive.debian.org/g /etc/apt/sources.list && \
+    sed -i s/security.debian.org/archive.debian.org/g /etc/apt/sources.list && \
+    sed -i s/stretch-updates/stretch/g /etc/apt/sources.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends postgresql-client && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/src/app
 COPY Gemfile* ./


### PR DESCRIPTION
Changes:

* Used `sed` to switch package repositories to "archive" because OS images is now End Of Life

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the `main` branch
* [x] Pull request includes a [sign off](../CONTRIBUTING.md#sign-off)

<!-- SIGN OFF -->
<!-- Uncomment below and fill in your details to sign off this PR -->
<!-- Signed-off-by: Your Name <your@email.example.org> -->
