### PR TITLE
Automatically confirm user when authenticated via Google SSO

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -336,7 +336,7 @@ GEM
     rb-fsevent (0.11.1)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    redcarpet (3.5.1)
+    redcarpet (3.6.1)
     redis (4.7.1)
     regexp_parser (2.5.0)
     responders (3.0.1)

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -62,6 +62,8 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     user = User.find_by_email data['email']
     user ||= new_user_from_google(data)
     update_user_info_from_google user, data
+    # Automatically mark user as "confirmed" if logging in via Google SSO
+    user.confirmed_at = Time.now.in_time_zone(LAST_COMPETITION_TIME_ZONE) if user.confirmed_at.blank?
     user.save
     user
   end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,6 +43,8 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
+  config.action_mailer.default_url_options = { host: ENV['DOMAIN'] || 'localhost' }
+
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 

--- a/test/controllers/users/omniauth_callbacks_controller_test.rb
+++ b/test/controllers/users/omniauth_callbacks_controller_test.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Users::OmniauthCallbacksControllerTest < ActionDispatch::IntegrationTest
+  GOOGLE_USER = 'test@google.com'
+  CONFIRM_DATE = Time.new(2025, 1, 1)
+
+  setup do
+    OmniAuth.config.test_mode = true
+  end
+
+  test 'should confirm a new user' do
+    OmniAuth.config.mock_auth[:google] = OmniAuth::AuthHash.new(
+      {
+        provider: 'google',
+        uid: '1234567890',
+        info: {
+          email: GOOGLE_USER,
+          name: 'Google User',
+          image: 'google avatar',
+        },
+      },
+    )
+
+    assert_difference('User.count', 1) do
+      User.find_by_email(GOOGLE_USER).tap do |user|
+        assert_nil user
+      end
+
+      get '/users/auth/google/callback'
+
+      User.find_by_email(GOOGLE_USER).tap do |user|
+        assert user.confirmed?
+      end
+    end
+  end
+
+  test 'should confirm an existing un-confirmed user' do
+    OmniAuth.config.mock_auth[:google] = OmniAuth::AuthHash.new(
+      {
+        provider: 'google',
+        uid: '1234567890',
+        info: {
+          email: GOOGLE_USER,
+          name: 'Google User',
+          image: 'google avatar',
+        },
+      },
+    )
+
+    assert_difference('User.count', 1) do
+      User.create!(email: GOOGLE_USER, password: Devise.friendly_token[0, 20])
+
+      User.find_by_email(GOOGLE_USER).tap do |user|
+        assert_not user.confirmed?
+      end
+
+      get '/users/auth/google/callback'
+
+      User.find_by_email(GOOGLE_USER).tap do |user|
+        assert user.confirmed?
+      end
+    end
+  end
+
+  test 'should not re-confirm an existing confirmed user' do
+    OmniAuth.config.mock_auth[:google] = OmniAuth::AuthHash.new(
+      {
+        provider: 'google',
+        uid: '1234567890',
+        info: {
+          email: GOOGLE_USER,
+          name: 'Google User',
+          image: 'google avatar',
+        },
+      },
+    )
+
+    assert_difference('User.count', 1) do
+      User.create!(email: GOOGLE_USER, password: Devise.friendly_token[0, 20], confirmed_at: CONFIRM_DATE)
+
+      User.find_by_email(GOOGLE_USER).tap do |user|
+        assert user.confirmed?
+      end
+
+      get '/users/auth/google/callback'
+
+      User.find_by_email(GOOGLE_USER).tap do |user|
+        assert user.confirmed?
+      end
+
+      User.find_by_email(GOOGLE_USER).tap do |user|
+        assert_equal user.confirmed_at, CONFIRM_DATE
+      end
+    end
+  end
+end


### PR DESCRIPTION
Changes:

* Gemfile.lock - Redcarpet upgraded to 3.6.1 to resolve test warnings
* Users::OmniauthCallbacksController - Set confirmed_at when successful authentication via Google SSO and user is not yet confirmed
* Updated integration tests
* Updated Test config to set default host for ActionMailer - Similar to other environments (e.g. Development, Stage and Production)

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the `main` branch
* [x] Pull request includes a [sign off](../CONTRIBUTING.md#sign-off)

<!-- SIGN OFF -->
<!-- Uncomment below and fill in your details to sign off this PR -->
<!-- Signed-off-by: Your Name <your@email.example.org> -->
