### PR TITLE
Make the Google button label different between Login and Registration

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -5,7 +5,7 @@
       <h2 class="heading">Register for GovHack <%= @competition.year %></h2>
       <%= render 'components/registration_status', page: 'sign_up' %>
       <div class="google-oath">
-        <%= link_to (render "devise/shared/google"), user_google_omniauth_authorize_path, method: :post %>
+        <%= link_to (render "devise/shared/google", locals: { google_label: 'Sign up with Google' }), user_google_omniauth_authorize_path, method: :post %>
         <hr class="grey-border">
         <p class="alt-text">or register below</p>
       </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -4,7 +4,7 @@
     <section class="signup-form">
       <h2 class="heading">Log in to Hackerspace</h2>
       <div class="google-oath">
-        <%= link_to (render "devise/shared/google"), user_google_omniauth_authorize_path, method: :post %>
+        <%= link_to (render "devise/shared/google", locals: { google_label: 'Log in with Google'}), user_google_omniauth_authorize_path, method: :post %>
         <hr class="grey-border">
         <p class="alt-text"> or log in below</p>
       </div>

--- a/app/views/devise/shared/_google.html.erb
+++ b/app/views/devise/shared/_google.html.erb
@@ -14,8 +14,7 @@
       </div>
     </div>
     <div class="message">
-      <p>Sign up with Google</p>
-      <p>Log in with Google</p>
+      <p><%= locals[:google_label] %></p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Changes:

* Change the shared Devise view use a local variable to define the Google button label
* Define the value of the Google button label in the Login and Registration views
* Remove unused label

Screenshot of changes:

Login:
<img width="2798" height="1723" alt="image" src="https://github.com/user-attachments/assets/a41d11e4-ce6b-4cf0-92b9-0a4b1fd4ca58" />


Register:
<img width="2791" height="1718" alt="image" src="https://github.com/user-attachments/assets/6a60519d-6dcf-443d-bd44-eee6f97ea7d8" />


### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the `main` branch
* [ ] Pull request includes a [sign off](../CONTRIBUTING.md#sign-off)

<!-- SIGN OFF -->
<!-- Uncomment below and fill in your details to sign off this PR -->
<!-- Signed-off-by: Your Name <your@email.example.org> -->
